### PR TITLE
[be][schedule] 일정 생성 api 구현 및 rest-docs 생성

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -18,6 +18,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -59,6 +60,7 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 dependencyManagement {
@@ -74,5 +76,30 @@ tasks.named('test') {
 
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
     dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from ("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
+}
+
+// static/docs 폴더 비우기
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+// build 의 의존작업 명시
+build {
+    dependsOn copyDocument
 }

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -1,0 +1,13 @@
+= ROUBY REST Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[introduction]]
+== 소개
+ROUBY의 API Docs 입니다.
+
+include::src/docs/asciidoc/schedule.adoc[]

--- a/back/src/docs/asciidoc/schedule.adoc
+++ b/back/src/docs/asciidoc/schedule.adoc
@@ -1,0 +1,7 @@
+[[SCHEDULE-API]]
+== Schedule-API
+
+[[Create-Schedule]]
+=== Schedule 등록
+
+operation::create-schedule-201[snippets='http-request,http-response,request-fields,curl-request']

--- a/back/src/main/java/com/rouby/schedule/application/dto/command/CreateScheduleCommand.java
+++ b/back/src/main/java/com/rouby/schedule/application/dto/command/CreateScheduleCommand.java
@@ -5,10 +5,8 @@ import com.rouby.schedule.domain.enums.ByDay;
 import com.rouby.schedule.domain.enums.Freq;
 import com.rouby.schedule.domain.vo.RecurrenceRule;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.stream.Collectors;
+import java.time.ZonedDateTime;
 import lombok.Builder;
 
 @Builder
@@ -35,7 +33,7 @@ public record CreateScheduleCommand(
         .startTime(startTime)
         .endDate(endDate)
         .endTime(endTime)
-        .recurrenceRule(recurrenceRule.toDomain())
+        .recurrenceRule((recurrenceRule != null) ? recurrenceRule.toDomain() : null)
         .build();
   }
 
@@ -44,14 +42,14 @@ public record CreateScheduleCommand(
       String freq,
       String byDay,
       Integer interval,
-      LocalDateTime until
+      ZonedDateTime until
   ) {
 
     public RecurrenceRule toDomain() {
 
       return RecurrenceRule.builder()
-          .freq(Freq.valueOf(freq))
-          .byDay(Arrays.stream(byDay.split(",")).map(ByDay::valueOf).collect(Collectors.toSet()))
+          .freq(Freq.parse(freq))
+          .byDay(ByDay.parseStringToSet(byDay))
           .interval(interval)
           .until(until)
           .build();

--- a/back/src/main/java/com/rouby/schedule/application/dto/command/CreateScheduleCommand.java
+++ b/back/src/main/java/com/rouby/schedule/application/dto/command/CreateScheduleCommand.java
@@ -3,6 +3,7 @@ package com.rouby.schedule.application.dto.command;
 import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.enums.ByDay;
 import com.rouby.schedule.domain.enums.Freq;
+import com.rouby.schedule.domain.vo.Period;
 import com.rouby.schedule.domain.vo.RecurrenceRule;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -22,17 +23,20 @@ public record CreateScheduleCommand(
     RecurrenceRuleCommand recurrenceRule
 ) {
 
-  public Schedule toEntity() {
+  public Schedule toEntityWithUserId(Long userId) {
 
     return Schedule.builder()
+        .userId(userId)
         .title(title)
         .memo(memo)
         .alarmOffsetMinutes(alarmOffsetMinutes)
         .routineActivateDate(routineActivateDate)
-        .startDate(startDate)
-        .startTime(startTime)
-        .endDate(endDate)
-        .endTime(endTime)
+        .period(Period.builder()
+            .startDate(startDate)
+            .startTime(startTime)
+            .endDate(endDate)
+            .endTime(endTime)
+            .build())
         .recurrenceRule((recurrenceRule != null) ? recurrenceRule.toDomain() : null)
         .build();
   }

--- a/back/src/main/java/com/rouby/schedule/application/dto/command/CreateScheduleCommand.java
+++ b/back/src/main/java/com/rouby/schedule/application/dto/command/CreateScheduleCommand.java
@@ -1,0 +1,60 @@
+package com.rouby.schedule.application.dto.command;
+
+import com.rouby.schedule.domain.entity.Schedule;
+import com.rouby.schedule.domain.enums.ByDay;
+import com.rouby.schedule.domain.enums.Freq;
+import com.rouby.schedule.domain.vo.RecurrenceRule;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import lombok.Builder;
+
+@Builder
+public record CreateScheduleCommand(
+    String title,
+    String memo,
+    Integer alarmOffsetMinutes,
+    LocalDate routineActivateDate,
+    LocalDate startDate,
+    LocalTime startTime,
+    LocalDate endDate,
+    LocalTime endTime,
+    RecurrenceRuleCommand recurrenceRule
+) {
+
+  public Schedule toEntity() {
+
+    return Schedule.builder()
+        .title(title)
+        .memo(memo)
+        .alarmOffsetMinutes(alarmOffsetMinutes)
+        .routineActivateDate(routineActivateDate)
+        .startDate(startDate)
+        .startTime(startTime)
+        .endDate(endDate)
+        .endTime(endTime)
+        .recurrenceRule(recurrenceRule.toDomain())
+        .build();
+  }
+
+  @Builder
+  public record RecurrenceRuleCommand(
+      String freq,
+      String byDay,
+      Integer interval,
+      LocalDateTime until
+  ) {
+
+    public RecurrenceRule toDomain() {
+
+      return RecurrenceRule.builder()
+          .freq(Freq.valueOf(freq))
+          .byDay(Arrays.stream(byDay.split(",")).map(ByDay::valueOf).collect(Collectors.toSet()))
+          .interval(interval)
+          .until(until)
+          .build();
+    }
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/application/facade/ScheduleFacade.java
+++ b/back/src/main/java/com/rouby/schedule/application/facade/ScheduleFacade.java
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class ScheduleFacade {
 
-  private final ScheduleWriteService ScheduleWriteService;
+  private final ScheduleWriteService scheduleWriteService;
 
   public Long createSchedule(Long userId, CreateScheduleCommand command) {
-    return ScheduleWriteService.createSchedule(userId, command);
+    return scheduleWriteService.createSchedule(userId, command);
   }
 }

--- a/back/src/main/java/com/rouby/schedule/application/facade/ScheduleFacade.java
+++ b/back/src/main/java/com/rouby/schedule/application/facade/ScheduleFacade.java
@@ -1,5 +1,7 @@
 package com.rouby.schedule.application.facade;
 
+import com.rouby.schedule.application.dto.command.CreateScheduleCommand;
+import com.rouby.schedule.application.service.ScheduleWriteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,4 +9,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class ScheduleFacade {
 
+  private final ScheduleWriteService ScheduleWriteService;
+
+  public Long createSchedule(Long userId, CreateScheduleCommand command) {
+    return ScheduleWriteService.createSchedule(userId, command);
+  }
 }

--- a/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
+++ b/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
@@ -1,0 +1,23 @@
+package com.rouby.schedule.application.service;
+
+import com.rouby.schedule.application.dto.command.CreateScheduleCommand;
+import com.rouby.schedule.domain.entity.Schedule;
+import com.rouby.schedule.domain.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ScheduleWriteService {
+
+  private final ScheduleRepository scheduleRepository;
+
+  public Long createSchedule(Long userId, CreateScheduleCommand command) {
+
+    Schedule schedule = command.toEntity();
+    schedule.assignUserId(userId);
+    scheduleRepository.save(schedule);
+
+    return schedule.getId();
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
+++ b/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
@@ -14,8 +14,7 @@ public class ScheduleWriteService {
 
   public Long createSchedule(Long userId, CreateScheduleCommand command) {
 
-    Schedule schedule = command.toEntity();
-    schedule.assignUserId(userId);
+    Schedule schedule = command.toEntityWithUserId(userId);
     scheduleRepository.save(schedule);
 
     return schedule.getId();

--- a/back/src/main/java/com/rouby/schedule/domain/entity/RecurrenceRuleStringConverter.java
+++ b/back/src/main/java/com/rouby/schedule/domain/entity/RecurrenceRuleStringConverter.java
@@ -9,11 +9,13 @@ public class RecurrenceRuleStringConverter implements AttributeConverter<Recurre
 
   @Override
   public String convertToDatabaseColumn(RecurrenceRule attribute) {
+    if (attribute == null) return null;
     return attribute.toString();
   }
 
   @Override
   public RecurrenceRule convertToEntityAttribute(String dbData) {
+    if (dbData == null || dbData.isBlank()) return null;
     return RecurrenceRule.from(dbData);
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/entity/RecurrenceRuleStringConverter.java
+++ b/back/src/main/java/com/rouby/schedule/domain/entity/RecurrenceRuleStringConverter.java
@@ -1,0 +1,19 @@
+package com.rouby.schedule.domain.entity;
+
+import com.rouby.schedule.domain.vo.RecurrenceRule;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class RecurrenceRuleStringConverter implements AttributeConverter<RecurrenceRule, String> {
+
+  @Override
+  public String convertToDatabaseColumn(RecurrenceRule attribute) {
+    return attribute.toString();
+  }
+
+  @Override
+  public RecurrenceRule convertToEntityAttribute(String dbData) {
+    return RecurrenceRule.from(dbData);
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
@@ -71,7 +71,7 @@ public class Schedule extends BaseEntity {
   private LocalDate overrideDate;
 
   @Builder
-  public Schedule(Long userId, String title, String memo,
+  private Schedule(Long userId, String title, String memo,
       LocalDate startDate, LocalTime startTime, LocalDate endDate, LocalTime endTime,
       LocalDate routineActivateDate, Integer alarmOffsetMinutes, RecurrenceRule recurrenceRule) {
 

--- a/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
@@ -21,6 +21,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -87,17 +88,23 @@ public class Schedule extends BaseEntity {
 
   private void validate() {
 
-    if (!period.isValidRoutineActivateDate(routineActivateDate)) {
-      throw new IllegalArgumentException("루틴 활성 일자가 일정보다 나중일 수 없습니다.");
+    if (routineActivateDate != null) {
+      if (!period.isValidRoutineActivateDate(routineActivateDate)) {
+        throw new IllegalArgumentException("루틴 활성 일자가 일정보다 나중일 수 없습니다.");
+      }
     }
   }
 
   public void assignUserId(Long userId) {
+    if (this.userId != null) {
+      throw new IllegalStateException("일정의 이미 설정된 user 정보를 변경할 수 없습니다.");
+    }
     this.userId = userId;
   }
 
   public void relateParentSchedule(Schedule schedule) {
     this.parentSchedule = schedule;
+    if (this.parentSchedule.children == null) this.parentSchedule.children = new ArrayList<>();
     this.parentSchedule.children.add(this);
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/enums/AlarmOffsetType.java
+++ b/back/src/main/java/com/rouby/schedule/domain/enums/AlarmOffsetType.java
@@ -1,5 +1,6 @@
 package com.rouby.schedule.domain.enums;
 
+import java.util.Arrays;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -21,4 +22,11 @@ public enum AlarmOffsetType {
 
   private final Integer minutes;
   private final String desc;
+
+  public static AlarmOffsetType parse(Integer minutes) {
+    return Arrays.stream(AlarmOffsetType.values())
+        .filter(type -> type.minutes.equals(minutes))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("지원되지 않는 알림 설정 시간(분) 정보입니다."));
+  }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/enums/ByDay.java
+++ b/back/src/main/java/com/rouby/schedule/domain/enums/ByDay.java
@@ -1,5 +1,10 @@
 package com.rouby.schedule.domain.enums;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public enum ByDay {
   SU,
   MO,
@@ -9,4 +14,22 @@ public enum ByDay {
   FR,
   SA
   ;
+
+  public static Set<ByDay> parseStringToSet(String byDayStr) {
+
+    Set<ByDay> byDaySet = Collections.emptySet();
+
+    if (byDayStr != null && !byDayStr.trim().isEmpty()) {
+      try {
+        byDaySet = Arrays.stream(byDayStr.split(","))
+            .map(String::trim)
+            .filter(day -> !day.isEmpty())
+            .map(ByDay::valueOf)
+            .collect(Collectors.toSet());
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("잘못된 요일 값이 포함되어 있습니다: " + byDayStr, e);
+      }
+    }
+    return byDaySet;
+  }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/enums/ByDay.java
+++ b/back/src/main/java/com/rouby/schedule/domain/enums/ByDay.java
@@ -1,0 +1,12 @@
+package com.rouby.schedule.domain.enums;
+
+public enum ByDay {
+  SU,
+  MO,
+  TU,
+  WE,
+  TH,
+  FR,
+  SA
+  ;
+}

--- a/back/src/main/java/com/rouby/schedule/domain/enums/Freq.java
+++ b/back/src/main/java/com/rouby/schedule/domain/enums/Freq.java
@@ -15,9 +15,22 @@ public enum Freq {
 
   private final Predicate<Integer> intervalValidator;
 
+  public static Freq parse(String freq) {
+
+    if (freq == null || freq.isBlank()) return null;
+
+    Freq frequency;
+    try {
+      frequency = Freq.valueOf(freq);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("잘못된 빈도 값입니다: " + freq, e);
+    }
+    return frequency;
+  }
+
   public void validateInterval(Integer interval) {
     if (interval == null || !intervalValidator.test(interval)) {
-      throw new IllegalArgumentException(interval + "은" + this.name() +"반복에 부적절한 인터벌 값입니다.");
+      throw new IllegalArgumentException(interval + "은(는) " + this.name() +"반복에 부적절한 인터벌 값입니다.");
     }
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/enums/Freq.java
+++ b/back/src/main/java/com/rouby/schedule/domain/enums/Freq.java
@@ -1,0 +1,23 @@
+package com.rouby.schedule.domain.enums;
+
+import java.util.function.Predicate;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Freq {
+  HOURLY(interval -> interval >= 1 && interval <= 24),
+  DAILY(interval -> interval >= 1 && interval <= 30),
+  WEEKLY(interval -> interval >= 1 && interval <= 12),
+  MONTHLY(interval -> interval >= 1 && interval <= 12),
+  YEARLY(interval -> interval >= 1 && interval <= 10),
+  ;
+
+  private final Predicate<Integer> intervalValidator;
+
+  public void validateInterval(Integer interval) {
+    if (interval == null || !intervalValidator.test(interval)) {
+      throw new IllegalArgumentException(interval + "은" + this.name() +"반복에 부적절한 인터벌 값입니다.");
+    }
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/domain/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/rouby/schedule/domain/repository/ScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.rouby.schedule.domain.repository;
+
+import com.rouby.schedule.domain.entity.Schedule;
+
+public interface ScheduleRepository {
+
+  Schedule save(Schedule entity);
+}

--- a/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
@@ -1,0 +1,29 @@
+package com.rouby.schedule.domain.vo;
+
+import com.rouby.schedule.domain.enums.OverrideType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OverrideInfo {
+
+  @Enumerated(EnumType.STRING)
+  private OverrideType overrideType;
+
+  private LocalDate overrideDate;
+
+  @Builder
+  private OverrideInfo(OverrideType overrideType, LocalDate overrideDate) {
+
+    this.overrideType = overrideType;
+    this.overrideDate = overrideDate;
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/domain/vo/Period.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/Period.java
@@ -7,13 +7,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
 @Embeddable
 @EqualsAndHashCode
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Period {
 
@@ -32,6 +30,7 @@ public class Period {
   public Period(LocalDate startDate, LocalTime startTime, LocalDate endDate, LocalTime endTime) {
 
     validate(startDate, startTime, endDate, endTime);
+
     this.startDate = startDate;
     this.startTime = startTime;
     this.endDate = endDate;
@@ -44,5 +43,9 @@ public class Period {
     LocalDateTime endDateTime = LocalDateTime.of(endDate, endTime);
     boolean result = !startDateTime.isAfter(endDateTime);
     Assert.isTrue(result, "시작일시가 종료일시보다 늦을 수 없습니다.");
+  }
+
+  public boolean isValidRoutineActivateDate(LocalDate routineActivateDate) {
+    return !routineActivateDate.isAfter(endDate);
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/vo/Period.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/Period.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
@@ -27,10 +28,10 @@ public class Period {
   @Column(nullable = false)
   private LocalTime endTime;
 
-  public Period(LocalDate startDate, LocalTime startTime, LocalDate endDate, LocalTime endTime) {
+  @Builder
+  private Period(LocalDate startDate, LocalTime startTime, LocalDate endDate, LocalTime endTime) {
 
     validate(startDate, startTime, endDate, endTime);
-
     this.startDate = startDate;
     this.startTime = startTime;
     this.endDate = endDate;

--- a/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
@@ -3,6 +3,7 @@ package com.rouby.schedule.domain.vo;
 
 import com.rouby.schedule.domain.enums.ByDay;
 import com.rouby.schedule.domain.enums.Freq;
+import jakarta.validation.constraints.NotNull;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -56,12 +57,9 @@ public class RecurrenceRule {
     return sb.toString();
   }
 
-  public static RecurrenceRule from(String str) {
-
-    if (str == null || str.isBlank()) return null;
+  public static RecurrenceRule from(@NotNull String str) {
 
     RecurrenceRule rRule = new RecurrenceRule();
-
     String[] split = str.split(";");
     Arrays.stream(split)
         .forEach(item -> {

--- a/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
@@ -26,7 +26,7 @@ public class RecurrenceRule {
 
 
   @Builder
-  public RecurrenceRule(Freq freq, Set<ByDay> byDay, Integer interval, ZonedDateTime until) {
+  private RecurrenceRule(Freq freq, Set<ByDay> byDay, Integer interval, ZonedDateTime until) {
     this.freq = freq;
     this.byDay = byDay;
     this.interval = interval;

--- a/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
@@ -57,6 +57,7 @@ public class RecurrenceRule {
     return sb.toString();
   }
 
+  // todo. @NotNull 동작 체크하기
   public static RecurrenceRule from(@NotNull String str) {
 
     RecurrenceRule rRule = new RecurrenceRule();

--- a/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
@@ -1,0 +1,103 @@
+package com.rouby.schedule.domain.vo;
+
+
+import com.rouby.schedule.domain.enums.ByDay;
+import com.rouby.schedule.domain.enums.Freq;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@NoArgsConstructor
+public class RecurrenceRule {
+
+  private Freq freq;
+  private Set<ByDay> byDay;
+  private Integer interval;
+  private LocalDateTime until;
+
+
+  @Builder
+  public RecurrenceRule(Freq freq, Set<ByDay> byDay, Integer interval, LocalDateTime until) {
+    this.freq = freq;
+    this.byDay = byDay;
+    this.interval = interval;
+    this.until = until;
+    validate();
+  }
+
+  public void validate() {
+    this.freq.validateInterval(this.interval);
+  }
+
+  @Override
+  public String toString() {
+
+    String separator = ";";
+
+    String byDayStr = String.join(",", byDay.stream().map(Enum::name).toList());
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssX");
+    String untilStr = formatter.format(until);
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("FREQ=").append(freq).append(separator)
+        .append("BYDAY=").append(byDayStr).append(separator)
+        .append("INTERVAL=").append(interval).append(separator)
+        .append("UNTIL=").append(untilStr).append(separator);
+
+    return sb.toString();
+  }
+
+  public static RecurrenceRule from(String str) {
+
+    RecurrenceRule rRule = new RecurrenceRule();
+
+    String[] splited = str.split(";");
+    Arrays.stream(splited)
+        .forEach(item -> {
+          String[] keyVal = item.split("=");
+
+          RuleType ruleType = RuleType.valueOf(keyVal[0].trim().toUpperCase());
+          Object val = ruleType.convert(keyVal[1].trim());
+          ruleType.setRule(rRule, val);
+        });
+
+    rRule.validate();
+    return rRule;
+  }
+
+
+  @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+  enum RuleType {
+    FREQ(str -> Freq.valueOf(str),
+        (rrule, freq) -> rrule.freq = (Freq) freq),
+    BYDAY(str -> Arrays.stream(str.split(","))
+        .map(ByDay::valueOf)
+        .collect(Collectors.toSet()),
+        (rrule, byDay) -> rrule.byDay = (Set<ByDay>) byDay),
+    INTERVAL(str -> Integer.valueOf(str),
+        (rrule, interval) -> rrule.interval = (Integer) interval),
+    UNTIL(str -> LocalDate.parse(str, DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssX")),
+        (rrule, until) -> rrule.until = (LocalDateTime) until),
+    ;
+
+    private final Function<String, Object> stringConverter;
+    private final BiConsumer<RecurrenceRule, Object> ruleSetter;
+
+    public Object convert(String trim) {
+      return this.stringConverter.apply(trim);
+    }
+
+    public void setRule(RecurrenceRule rrule, Object val) {
+      this.ruleSetter.accept(rrule, val);
+    }
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepository.java
+++ b/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepository.java
@@ -1,8 +1,10 @@
 package com.rouby.schedule.infrastructure.persistence.jpa;
 
 import com.rouby.schedule.domain.entity.Schedule;
+import com.rouby.schedule.domain.repository.ScheduleRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ScheduleJpaRepository extends JpaRepository<Schedule, Long>, ScheduleJpaRepositoryCustom {
+public interface ScheduleJpaRepository extends ScheduleRepository,
+    JpaRepository<Schedule, Long>, ScheduleJpaRepositoryCustom {
 
 }

--- a/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
@@ -10,6 +10,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -24,7 +25,7 @@ public class ScheduleController {
   @PreAuthorize("hasAnyRole('USER')")
   @PutMapping
   public ResponseEntity<Void> createSchedule(
-      @AuthenticationPrincipal UserDetailsImpl userDetails, @Validated CreateScheduleRequest req) {
+      @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody @Validated CreateScheduleRequest req) {
 
     Long scheduleId = scheduleFacade.createSchedule(userDetails.getId(), req.toCommand());
     URI location =  ServletUriComponentsBuilder

--- a/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +23,7 @@ public class ScheduleController {
   private final ScheduleFacade scheduleFacade;
 
   @PreAuthorize("hasAnyRole('USER')")
-  @PutMapping
+  @PostMapping
   public ResponseEntity<Void> createSchedule(
       @AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody @Validated CreateScheduleRequest req) {
 

--- a/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
@@ -1,9 +1,18 @@
 package com.rouby.schedule.presentation;
 
+import com.rouby.auth.dto.UserDetailsImpl;
 import com.rouby.schedule.application.facade.ScheduleFacade;
+import com.rouby.schedule.presentation.dto.request.CreateScheduleRequest;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
 @RequestMapping("/api/v1/schedules")
@@ -11,4 +20,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleController {
 
   private final ScheduleFacade scheduleFacade;
+
+  @PreAuthorize("hasAnyRole('USER')")
+  @PutMapping
+  public ResponseEntity<Void> createSchedule(
+      @AuthenticationPrincipal UserDetailsImpl userDetails, @Validated CreateScheduleRequest req) {
+
+    Long scheduleId = scheduleFacade.createSchedule(userDetails.getId(), req.toCommand());
+    URI location =  ServletUriComponentsBuilder
+        .fromCurrentRequestUri()
+        .path("/{scheduleId}")
+        .buildAndExpand(scheduleId)
+        .toUri();
+    return ResponseEntity.created(location).build();
+  }
 }

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/request/CreateScheduleRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/request/CreateScheduleRequest.java
@@ -1,0 +1,64 @@
+package com.rouby.schedule.presentation.dto.request;
+
+import com.rouby.schedule.application.dto.command.CreateScheduleCommand;
+import com.rouby.schedule.application.dto.command.CreateScheduleCommand.RecurrenceRuleCommand;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.springframework.validation.annotation.Validated;
+
+
+public record CreateScheduleRequest (
+  @NotBlank @Size(max = 500) String title,
+  @Size(max = 10_000) String memo,
+  @Pattern(regexp = "^(5|10|15|30|60|120|1440|2880|10080)$")
+  Integer alarmOffsetMinutes,
+  @FutureOrPresent LocalDate routineActivateDate,
+  @NotNull LocalDate startDate,
+  @NotNull LocalTime startTime,
+  @NotNull LocalDate endDate,
+  @NotNull LocalTime endTime,
+  @Validated RecurrenceRuleRequest recurrenceRule
+  ) {
+
+  public CreateScheduleCommand toCommand() {
+    return CreateScheduleCommand.builder()
+        .title(title)
+        .memo(memo)
+        .alarmOffsetMinutes(alarmOffsetMinutes)
+        .routineActivateDate(routineActivateDate)
+        .startDate(startDate)
+        .startTime(startTime)
+        .endDate(endDate)
+        .endTime(endTime)
+        .recurrenceRule(recurrenceRule.toCommand())
+        .build();
+  }
+
+  record RecurrenceRuleRequest(
+      @Pattern(regexp = "^(HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)$")
+      String freq,
+      @Pattern(regexp = "^(MO|TU|WE|TH|FR|SA|SU)(,(MO|TU|WE|TH|FR|SA|SU))*$")
+      String byDay,
+      @Positive @Max(30) Integer interval,
+      @Future LocalDateTime until
+  ) {
+
+    public RecurrenceRuleCommand toCommand() {
+      return RecurrenceRuleCommand.builder()
+          .freq(freq)
+          .byDay(byDay)
+          .interval(interval)
+          .until(until)
+          .build();
+    }
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/request/CreateScheduleRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/request/CreateScheduleRequest.java
@@ -9,18 +9,20 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import lombok.Builder;
 import org.springframework.validation.annotation.Validated;
 
-
+@Builder
 public record CreateScheduleRequest (
+
   @NotBlank @Size(max = 500) String title,
   @Size(max = 10_000) String memo,
-  @Pattern(regexp = "^(5|10|15|30|60|120|1440|2880|10080)$")
-  Integer alarmOffsetMinutes,
+  @PositiveOrZero @Max(10080) Integer alarmOffsetMinutes,
   @FutureOrPresent LocalDate routineActivateDate,
   @NotNull LocalDate startDate,
   @NotNull LocalTime startTime,
@@ -43,7 +45,8 @@ public record CreateScheduleRequest (
         .build();
   }
 
-  record RecurrenceRuleRequest(
+  @Builder
+  public record RecurrenceRuleRequest(
       @Pattern(regexp = "^(HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY)$")
       String freq,
       @Pattern(regexp = "^(MO|TU|WE|TH|FR|SA|SU)(,(MO|TU|WE|TH|FR|SA|SU))*$")

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/request/CreateScheduleRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/request/CreateScheduleRequest.java
@@ -12,10 +12,9 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import lombok.Builder;
-import org.springframework.validation.annotation.Validated;
 
 @Builder
 public record CreateScheduleRequest (
@@ -28,7 +27,7 @@ public record CreateScheduleRequest (
   @NotNull LocalTime startTime,
   @NotNull LocalDate endDate,
   @NotNull LocalTime endTime,
-  @Validated RecurrenceRuleRequest recurrenceRule
+  RecurrenceRuleRequest recurrenceRule
   ) {
 
   public CreateScheduleCommand toCommand() {
@@ -41,7 +40,7 @@ public record CreateScheduleRequest (
         .startTime(startTime)
         .endDate(endDate)
         .endTime(endTime)
-        .recurrenceRule(recurrenceRule.toCommand())
+        .recurrenceRule((recurrenceRule != null) ? recurrenceRule.toCommand() : null)
         .build();
   }
 
@@ -52,7 +51,7 @@ public record CreateScheduleRequest (
       @Pattern(regexp = "^(MO|TU|WE|TH|FR|SA|SU)(,(MO|TU|WE|TH|FR|SA|SU))*$")
       String byDay,
       @Positive @Max(30) Integer interval,
-      @Future LocalDateTime until
+      @Future ZonedDateTime until
   ) {
 
     public RecurrenceRuleCommand toCommand() {

--- a/back/src/main/resources/static/docs/index.html
+++ b/back/src/main/resources/static/docs/index.html
@@ -474,10 +474,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="Create-Schedule_http_request"><a class="link" href="#Create-Schedule_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/schedules HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/schedules HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer {ACCESS_TOKEN}
-Content-Length: 397
+Content-Length: 398
 Host: localhost:8080
 
 {
@@ -493,7 +493,7 @@ Host: localhost:8080
     "freq" : "MONTHLY",
     "byDay" : "MO",
     "interval" : 1,
-    "until" : "2025-12-30T00:00:00"
+    "until" : "2025-12-30T00:00:00Z"
   }
 }</code></pre>
 </div>
@@ -547,12 +547,12 @@ Location: http://localhost:8080/api/v1/schedules/1</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>startTime</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">시작 시간 (예: 2025-08-30)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 시간 (예: 13:00:00)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">종료 일자 (예: 13:00:00)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 일자 (예: 2025-08-30)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>endTime</code></p></td>
@@ -596,7 +596,7 @@ Location: http://localhost:8080/api/v1/schedules/1</code></pre>
 <h4 id="Create-Schedule_curl_request"><a class="link" href="#Create-Schedule_curl_request">Curl request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/api/v1/schedules' -i -X PUT \
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/api/v1/schedules' -i -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer {ACCESS_TOKEN}' \
     -d '{
@@ -612,7 +612,7 @@ Location: http://localhost:8080/api/v1/schedules/1</code></pre>
     "freq" : "MONTHLY",
     "byDay" : "MO",
     "interval" : 1,
-    "until" : "2025-12-30T00:00:00"
+    "until" : "2025-12-30T00:00:00Z"
   }
 }'</code></pre>
 </div>

--- a/back/src/main/resources/static/docs/index.html
+++ b/back/src/main/resources/static/docs/index.html
@@ -1,0 +1,639 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.18">
+<title>ROUBY REST Docs</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>ROUBY REST Docs</h1>
+<div class="details">
+<span id="revnumber">version 0.0.1-SNAPSHOT</span>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#introduction">소개</a></li>
+<li><a href="#SCHEDULE-API">Schedule-API</a>
+<ul class="sectlevel2">
+<li><a href="#Create-Schedule">Schedule 등록</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="introduction"><a class="link" href="#introduction">소개</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>ROUBY의 API Docs 입니다.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="SCHEDULE-API"><a class="link" href="#SCHEDULE-API">Schedule-API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Create-Schedule"><a class="link" href="#Create-Schedule">Schedule 등록</a></h3>
+<div class="sect3">
+<h4 id="Create-Schedule_http_request"><a class="link" href="#Create-Schedule_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/schedules HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {ACCESS_TOKEN}
+Content-Length: 397
+Host: localhost:8080
+
+{
+  "title" : "하이들 모임!",
+  "memo" : "뭉티기 먹을 것!",
+  "alarmOffsetMinutes" : 1440,
+  "routineActivateDate" : "2025-07-07",
+  "startDate" : "2025-07-21",
+  "startTime" : "10:30:00",
+  "endDate" : "2025-07-21",
+  "endTime" : "22:30:00",
+  "recurrenceRule" : {
+    "freq" : "MONTHLY",
+    "byDay" : "MO",
+    "interval" : 1,
+    "until" : "2025-12-30T00:00:00"
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Create-Schedule_http_response"><a class="link" href="#Create-Schedule_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Location: http://localhost:8080/api/v1/schedules/1</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Create-Schedule_request_fields"><a class="link" href="#Create-Schedule_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">일정 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">일정 메모</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>alarmOffsetMinutes</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">일정 전 알림 시간 설정 (5, 10, 15, 30 분 / 1, 2시간 / 1, 2 일 / 1주일 전</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 일자 (예: 2025-08-30)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 시간 (예: 2025-08-30)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 일자 (예: 13:00:00)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 시간 (예: 15:00:00)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>routineActivateDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">루틴 활성 시점 (예: 2025-08-10)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 규칙</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule.freq</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 주기 (예: MONTHLY)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule.byDay</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 요일 (예: MO)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule.interval</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 간격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule.until</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 종료일 (예: 2025-12-30T00:00:00)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Create-Schedule_curl_request"><a class="link" href="#Create-Schedule_curl_request">Curl request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/api/v1/schedules' -i -X PUT \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer {ACCESS_TOKEN}' \
+    -d '{
+  "title" : "하이들 모임!",
+  "memo" : "뭉티기 먹을 것!",
+  "alarmOffsetMinutes" : 1440,
+  "routineActivateDate" : "2025-07-07",
+  "startDate" : "2025-07-21",
+  "startTime" : "10:30:00",
+  "endDate" : "2025-07-21",
+  "endTime" : "22:30:00",
+  "recurrenceRule" : {
+    "freq" : "MONTHLY",
+    "byDay" : "MO",
+    "interval" : 1,
+    "until" : "2025-12-30T00:00:00"
+  }
+}'</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2025-07-07 00:54:29 +0900
+</div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>
+<script>
+if (!hljs.initHighlighting.called) {
+  hljs.initHighlighting.called = true
+  ;[].slice.call(document.querySelectorAll('pre.highlight > code[data-lang]')).forEach(function (el) { hljs.highlightBlock(el) })
+}
+</script>
+</body>
+</html>

--- a/back/src/main/resources/static/docs/schedule.html
+++ b/back/src/main/resources/static/docs/schedule.html
@@ -449,10 +449,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="Create-Schedule_http_request">HTTP request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/schedules HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/v1/schedules HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer {ACCESS_TOKEN}
-Content-Length: 397
+Content-Length: 398
 Host: localhost:8080
 
 {
@@ -468,7 +468,7 @@ Host: localhost:8080
     "freq" : "MONTHLY",
     "byDay" : "MO",
     "interval" : 1,
-    "until" : "2025-12-30T00:00:00"
+    "until" : "2025-12-30T00:00:00Z"
   }
 }</code></pre>
 </div>
@@ -522,12 +522,12 @@ Location: http://localhost:8080/api/v1/schedules/1</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>startTime</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">시작 시간 (예: 2025-08-30)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 시간 (예: 13:00:00)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">종료 일자 (예: 13:00:00)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 일자 (예: 2025-08-30)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>endTime</code></p></td>
@@ -571,7 +571,7 @@ Location: http://localhost:8080/api/v1/schedules/1</code></pre>
 <h4 id="Create-Schedule_curl_request">Curl request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/v1/schedules' -i -X PUT \
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/v1/schedules' -i -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer {ACCESS_TOKEN}' \
     -d '{
@@ -587,7 +587,7 @@ Location: http://localhost:8080/api/v1/schedules/1</code></pre>
     "freq" : "MONTHLY",
     "byDay" : "MO",
     "interval" : 1,
-    "until" : "2025-12-30T00:00:00"
+    "until" : "2025-12-30T00:00:00Z"
   }
 }'</code></pre>
 </div>

--- a/back/src/main/resources/static/docs/schedule.html
+++ b/back/src/main/resources/static/docs/schedule.html
@@ -1,0 +1,607 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.18">
+<title>Schedule-API</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="SCHEDULE-API">Schedule-API</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Create-Schedule">Schedule 등록</h3>
+<div class="sect3">
+<h4 id="Create-Schedule_http_request">HTTP request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /api/v1/schedules HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {ACCESS_TOKEN}
+Content-Length: 397
+Host: localhost:8080
+
+{
+  "title" : "하이들 모임!",
+  "memo" : "뭉티기 먹을 것!",
+  "alarmOffsetMinutes" : 1440,
+  "routineActivateDate" : "2025-07-07",
+  "startDate" : "2025-07-21",
+  "startTime" : "10:30:00",
+  "endDate" : "2025-07-21",
+  "endTime" : "22:30:00",
+  "recurrenceRule" : {
+    "freq" : "MONTHLY",
+    "byDay" : "MO",
+    "interval" : 1,
+    "until" : "2025-12-30T00:00:00"
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Create-Schedule_http_response">HTTP response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
+Location: http://localhost:8080/api/v1/schedules/1</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Create-Schedule_request_fields">Request fields</h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">일정 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">일정 메모</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>alarmOffsetMinutes</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">일정 전 알림 시간 설정 (5, 10, 15, 30 분 / 1, 2시간 / 1, 2 일 / 1주일 전</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 일자 (예: 2025-08-30)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>startTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">시작 시간 (예: 2025-08-30)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 일자 (예: 13:00:00)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>endTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">종료 시간 (예: 15:00:00)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>routineActivateDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">루틴 활성 시점 (예: 2025-08-10)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 규칙</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule.freq</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 주기 (예: MONTHLY)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule.byDay</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 요일 (예: MO)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule.interval</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 간격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>recurrenceRule.until</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">반복 종료일 (예: 2025-12-30T00:00:00)</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Create-Schedule_curl_request">Curl request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/v1/schedules' -i -X PUT \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer {ACCESS_TOKEN}' \
+    -d '{
+  "title" : "하이들 모임!",
+  "memo" : "뭉티기 먹을 것!",
+  "alarmOffsetMinutes" : 1440,
+  "routineActivateDate" : "2025-07-07",
+  "startDate" : "2025-07-21",
+  "startTime" : "10:30:00",
+  "endDate" : "2025-07-21",
+  "endTime" : "22:30:00",
+  "recurrenceRule" : {
+    "freq" : "MONTHLY",
+    "byDay" : "MO",
+    "interval" : 1,
+    "until" : "2025-12-30T00:00:00"
+  }
+}'</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2025-07-07 00:59:44 +0900
+</div>
+</div>
+</body>
+</html>

--- a/back/src/test/java/com/rouby/common/security/WithMockCustomUser.java
+++ b/back/src/test/java/com/rouby/common/security/WithMockCustomUser.java
@@ -9,7 +9,7 @@ import org.springframework.security.test.context.support.WithSecurityContext;
 @WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
 public @interface WithMockCustomUser {
 
-    long id() default 1l;
+    long id() default 1L;
     String email() default "test@example.com";
     String name() default "Rob Winch";
     UserRole role() default UserRole.USER;

--- a/back/src/test/java/com/rouby/common/security/WithMockCustomUser.java
+++ b/back/src/test/java/com/rouby/common/security/WithMockCustomUser.java
@@ -1,0 +1,17 @@
+package com.rouby.common.security;
+
+import com.rouby.user.domain.entity.UserRole;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+    long id() default 1l;
+    String email() default "test@example.com";
+    String name() default "Rob Winch";
+    UserRole role() default UserRole.USER;
+
+}

--- a/back/src/test/java/com/rouby/common/security/WithMockCustomUserSecurityContextFactory.java
+++ b/back/src/test/java/com/rouby/common/security/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,32 @@
+package com.rouby.common.security;
+
+
+import com.rouby.auth.dto.UserDetailsImpl;
+import java.util.Collections;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser customUserPrincipal) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        UserDetailsImpl principal = UserDetailsImpl.builder()
+                .id(customUserPrincipal.id())
+                .email(customUserPrincipal.email())
+                .build();
+
+        var authorities = Collections.
+                singletonList(new SimpleGrantedAuthority(customUserPrincipal.role().name()));
+
+        Authentication auth =
+                UsernamePasswordAuthenticationToken.authenticated(principal, "password", authorities);
+        context.setAuthentication(auth);
+        return context;
+    }
+}

--- a/back/src/test/java/com/rouby/common/support/ControllerTestSupport.java
+++ b/back/src/test/java/com/rouby/common/support/ControllerTestSupport.java
@@ -1,0 +1,30 @@
+package com.rouby.common.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rouby.schedule.presentation.ScheduleController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureRestDocs
+@WebMvcTest(
+    controllers = {ScheduleController.class,},
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE) //, classes = JwtAuthenticationFilter.class)
+    }
+)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+public abstract class ControllerTestSupport {
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+}

--- a/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
+++ b/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
@@ -1,5 +1,6 @@
 package com.rouby.schedule.presentation;
 
+import static java.time.ZoneOffset.UTC;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -22,6 +23,7 @@ import com.rouby.schedule.presentation.dto.request.CreateScheduleRequest.Recurre
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -58,7 +60,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
             .freq("MONTHLY")
             .interval(1)
             .byDay("MO")
-            .until(LocalDateTime.of(2025,12,30, 0, 0))
+            .until(ZonedDateTime.of(LocalDateTime.of(2025,12,30, 0, 0), UTC))
             .build())
         .build();
     var content = objectMapper.writeValueAsString(request);

--- a/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
+++ b/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
@@ -4,7 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -49,11 +49,11 @@ class ScheduleControllerTest extends ControllerTestSupport {
         .title("하이들 모임!")
         .memo("뭉티기 먹을 것!")
         .alarmOffsetMinutes(1440)
-        .startDate(LocalDate.now().plusDays(14))
+        .startDate(LocalDate.of(2025, 7, 21))
         .startTime(LocalTime.of(10, 30))
-        .endDate(LocalDate.now().plusDays(14))
+        .endDate(LocalDate.of(2025, 7, 21))
         .endTime(LocalTime.of(22, 30))
-        .routineActivateDate(LocalDate.now())
+        .routineActivateDate(LocalDate.of(2025, 7, 7))
         .recurrenceRule(RecurrenceRuleRequest.builder()
             .freq("MONTHLY")
             .interval(1)
@@ -68,7 +68,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
         .thenReturn(scheduleId);
 
     // when
-    ResultActions resultActions = mockMvc.perform(put("/api/v1/schedules")
+    ResultActions resultActions = mockMvc.perform(post("/api/v1/schedules")
         .header("Authorization", "Bearer {ACCESS_TOKEN}")
         .content(content)
         .contentType(MediaType.APPLICATION_JSON)
@@ -87,8 +87,8 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 fieldWithPath("memo").description("일정 메모"),
                 fieldWithPath("alarmOffsetMinutes").description("일정 전 알림 시간 설정 (5, 10, 15, 30 분 / 1, 2시간 / 1, 2 일 / 1주일 전"),
                 fieldWithPath("startDate").description("시작 일자 (예: 2025-08-30)"),
-                fieldWithPath("startTime").description("시작 시간 (예: 2025-08-30)"),
-                fieldWithPath("endDate").description("종료 일자 (예: 13:00:00)"),
+                fieldWithPath("startTime").description("시작 시간 (예: 13:00:00)"),
+                fieldWithPath("endDate").description("종료 일자 (예: 2025-08-30)"),
                 fieldWithPath("endTime").description("종료 시간 (예: 15:00:00)"),
                 fieldWithPath("routineActivateDate").description("루틴 활성 시점 (예: 2025-08-10)"),
                 fieldWithPath("recurrenceRule").description("반복 규칙"),

--- a/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
+++ b/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
@@ -1,0 +1,102 @@
+package com.rouby.schedule.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.rouby.common.security.WithMockCustomUser;
+import com.rouby.common.support.ControllerTestSupport;
+import com.rouby.schedule.application.facade.ScheduleFacade;
+import com.rouby.schedule.presentation.dto.request.CreateScheduleRequest;
+import com.rouby.schedule.presentation.dto.request.CreateScheduleRequest.RecurrenceRuleRequest;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+class ScheduleControllerTest extends ControllerTestSupport {
+
+  @MockitoBean
+  ScheduleFacade scheduleFacade;
+
+  @BeforeEach
+  void setUp() {
+  }
+
+  @WithMockCustomUser
+  @DisplayName("스케쥴 생성 API")
+  @Test
+  void createSchedule() throws Exception {
+
+    // given
+    var request = CreateScheduleRequest.builder()
+        .title("하이들 모임!")
+        .memo("뭉티기 먹을 것!")
+        .alarmOffsetMinutes(1440)
+        .startDate(LocalDate.now().plusDays(14))
+        .startTime(LocalTime.of(10, 30))
+        .endDate(LocalDate.now().plusDays(14))
+        .endTime(LocalTime.of(22, 30))
+        .routineActivateDate(LocalDate.now())
+        .recurrenceRule(RecurrenceRuleRequest.builder()
+            .freq("MONTHLY")
+            .interval(1)
+            .byDay("MO")
+            .until(LocalDateTime.of(2025,12,30, 0, 0))
+            .build())
+        .build();
+    var content = objectMapper.writeValueAsString(request);
+
+    var scheduleId = 1L;
+    when(scheduleFacade.createSchedule(any(Long.class), eq(request.toCommand())))
+        .thenReturn(scheduleId);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(put("/api/v1/schedules")
+        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+        .content(content)
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    resultActions.andExpect(status().isCreated())
+        .andExpect(header().string(
+            "Location", Matchers.endsWith(String.format("/api/v1/schedules/%s", scheduleId))))
+        .andDo(print())
+        .andDo(document("create-schedule-201",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("title").description("일정 제목"),
+                fieldWithPath("memo").description("일정 메모"),
+                fieldWithPath("alarmOffsetMinutes").description("일정 전 알림 시간 설정 (5, 10, 15, 30 분 / 1, 2시간 / 1, 2 일 / 1주일 전"),
+                fieldWithPath("startDate").description("시작 일자 (예: 2025-08-30)"),
+                fieldWithPath("startTime").description("시작 시간 (예: 2025-08-30)"),
+                fieldWithPath("endDate").description("종료 일자 (예: 13:00:00)"),
+                fieldWithPath("endTime").description("종료 시간 (예: 15:00:00)"),
+                fieldWithPath("routineActivateDate").description("루틴 활성 시점 (예: 2025-08-10)"),
+                fieldWithPath("recurrenceRule").description("반복 규칙"),
+                fieldWithPath("recurrenceRule.freq").description("반복 주기 (예: MONTHLY)"),
+                fieldWithPath("recurrenceRule.byDay").description("반복 요일 (예: MO)"),
+                fieldWithPath("recurrenceRule.interval").description("반복 간격"),
+                fieldWithPath("recurrenceRule.until").description("반복 종료일 (예: 2025-12-30T00:00:00)")
+            )
+        ));
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #11

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 일정 생성 api 추가
  - [x] 일정 도메인 보완
  - [x] 일정 생성 rest-docs 문서 추가

## 체크리스트
- [x] 관련 테스트를 추가했습니다.
- [x] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- 코드 동작은 화면 작업하면서 더 체크해보고, 수정할 거 있으면 수정 이슈 만들어서 또 올리도록 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 일정 생성 기능이 추가되었습니다. 사용자는 제목, 메모, 알림 시간, 루틴 활성화 날짜, 시작/종료 날짜 및 시간, 반복 규칙 등을 입력하여 일정을 등록할 수 있습니다.
  * 반복 규칙 설정(빈도, 요일, 반복 간격, 종료 시점 등)이 지원됩니다.
  * 일정 생성 시 유효성 검사가 자동으로 적용됩니다.
  * 일정 생성 후, 생성된 일정의 위치를 포함한 응답이 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->