### PR TITLE
[be][assistant] 어시스턴스 도메인 각각 생성

### DIFF
--- a/back/src/main/java/com/rouby/assistant/briefing/application/facade/BriefingFacade.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/application/facade/BriefingFacade.java
@@ -1,0 +1,13 @@
+package com.rouby.assistant.briefing.application.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Service
+@RequiredArgsConstructor
+public class BriefingFacade {}

--- a/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
@@ -41,6 +41,6 @@ public class Briefing extends BaseEntity {
     this.id = id;
     this.userId = userId;
     this.promptTemplateId = promptTemplateId;
-    this.briefingContent = new BriefingContent(prompt, content);
+    this.briefingContent = BriefingContent.of(prompt, content);
   }
 }

--- a/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
@@ -37,10 +37,11 @@ public class Briefing extends BaseEntity {
   private BriefingContent briefingContent;
 
   @Builder
-  public Briefing(Long id, Long userId, Long promptTemplateId, String prompt, String content) {
+  private Briefing(Long id, Long userId, Long promptTemplateId, String prompt, String content) {
     this.id = id;
     this.userId = userId;
     this.promptTemplateId = promptTemplateId;
     this.briefingContent = BriefingContent.of(prompt, content);
   }
+
 }

--- a/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
@@ -34,6 +34,7 @@ public class Briefing extends BaseEntity {
   private Long promptTemplateId;
 
   @Embedded
+  @Column(nullable = false)
   private BriefingContent briefingContent;
 
   @Builder

--- a/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
@@ -1,0 +1,46 @@
+package com.rouby.assistant.briefing.domain;
+
+
+import com.rouby.assistant.briefing.domain.vo.BriefingContent;
+import com.rouby.common.jpa.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ * @author : hanjihoon
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Briefing extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Column(nullable = false)
+  private Long promptTemplateId;
+
+  @Embedded
+  private BriefingContent briefingContent;
+
+  @Builder
+  public Briefing(Long id, Long userId, Long promptTemplateId, String prompt, String content) {
+    this.id = id;
+    this.userId = userId;
+    this.promptTemplateId = promptTemplateId;
+    this.briefingContent = new BriefingContent(prompt, content);
+  }
+}

--- a/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/domain/Briefing.java
@@ -34,7 +34,6 @@ public class Briefing extends BaseEntity {
   private Long promptTemplateId;
 
   @Embedded
-  @Column(nullable = false)
   private BriefingContent briefingContent;
 
   @Builder

--- a/back/src/main/java/com/rouby/assistant/briefing/domain/repository/BriefingRepository.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/domain/repository/BriefingRepository.java
@@ -1,0 +1,7 @@
+package com.rouby.assistant.briefing.domain.repository;
+/**
+ * @Date : 2025. 07. 07.
+ * @author : hanjihoon
+ */
+public interface BriefingRepository {
+}

--- a/back/src/main/java/com/rouby/assistant/briefing/domain/vo/BriefingContent.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/domain/vo/BriefingContent.java
@@ -22,8 +22,12 @@ public class BriefingContent {
   @Column(nullable = false, columnDefinition = "TEXT")
   private String content;
 
-  public BriefingContent(String prompt, String content) {
+  private BriefingContent(String prompt, String content) {
     this.prompt = prompt;
     this.content = content;
+  }
+
+  public static BriefingContent of(String prompt, String content){
+    return new BriefingContent(prompt, content);
   }
 }

--- a/back/src/main/java/com/rouby/assistant/briefing/domain/vo/BriefingContent.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/domain/vo/BriefingContent.java
@@ -1,0 +1,29 @@
+package com.rouby.assistant.briefing.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ * @author : hanjihoon
+ */
+@Embeddable
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BriefingContent {
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String prompt;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  public BriefingContent(String prompt, String content) {
+    this.prompt = prompt;
+    this.content = content;
+  }
+}

--- a/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepository.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepository.java
@@ -1,0 +1,13 @@
+package com.rouby.assistant.briefing.infrastructure.persistence.jpa;
+
+import com.rouby.assistant.briefing.domain.Briefing;
+import com.rouby.assistant.briefing.domain.repository.BriefingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public interface BriefingJpaRepository extends JpaRepository<Long, Briefing>,
+    BriefingJpaRepositoryCustom,BriefingRepository {}

--- a/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepository.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  *
  * @author : hanjihoon
  */
-public interface BriefingJpaRepository extends JpaRepository<Long, Briefing>,
+public interface BriefingJpaRepository extends JpaRepository<Briefing, Long>,
     BriefingJpaRepositoryCustom,BriefingRepository {}

--- a/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepositoryCustom.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.rouby.assistant.briefing.infrastructure.persistence.jpa;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public interface BriefingJpaRepositoryCustom {}

--- a/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepositoryCustomImpl.java
@@ -1,0 +1,15 @@
+package com.rouby.assistant.briefing.infrastructure.persistence.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@RequiredArgsConstructor
+public class BriefingJpaRepositoryCustomImpl implements BriefingJpaRepositoryCustom{
+
+  private final JPAQueryFactory jpaQueryFactory;
+}

--- a/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/infrastructure/persistence/jpa/BriefingJpaRepositoryCustomImpl.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
  * @author : hanjihoon
  */
 @RequiredArgsConstructor
-public class BriefingJpaRepositoryCustomImpl implements BriefingJpaRepositoryCustom{
+public class BriefingJpaRepositoryCustomImpl implements BriefingJpaRepositoryCustom {
 
   private final JPAQueryFactory jpaQueryFactory;
 }

--- a/back/src/main/java/com/rouby/assistant/briefing/presentation/BriefingController.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/presentation/BriefingController.java
@@ -10,6 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
  * @author : hanjihoon
  */
 @RestController
-@RequestMapping("/api/v1/assistant/feedback")
+@RequestMapping("/api/v1/assistants/briefings")
 @RequiredArgsConstructor
 public class BriefingController {}

--- a/back/src/main/java/com/rouby/assistant/briefing/presentation/BriefingController.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/presentation/BriefingController.java
@@ -1,0 +1,15 @@
+package com.rouby.assistant.briefing.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@RestController
+@RequestMapping("/api/v1/assistant/feedback")
+@RequiredArgsConstructor
+public class BriefingController {}

--- a/back/src/main/java/com/rouby/assistant/feedback/application/facade/FeedbackFacade.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/application/facade/FeedbackFacade.java
@@ -1,0 +1,13 @@
+package com.rouby.assistant.feedback.application.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Service
+@RequiredArgsConstructor
+public class FeedbackFacade {}

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/Feedback.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/Feedback.java
@@ -46,15 +46,12 @@ public class Feedback extends BaseEntity {
   private String userInput;
 
   @Embedded
-  @Column(nullable = false)
   private FeedbackContent feedbackContent;
 
   @Embedded
-  @Column(nullable = false)
   private StatusKeyword statusKeyword;
 
   @Embedded
-  @Column(nullable = false)
   private FeedbackKeyword feedbackKeyword;
 
   @Builder

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/Feedback.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/Feedback.java
@@ -46,12 +46,15 @@ public class Feedback extends BaseEntity {
   private String userInput;
 
   @Embedded
+  @Column(nullable = false)
   private FeedbackContent feedbackContent;
 
   @Embedded
+  @Column(nullable = false)
   private StatusKeyword statusKeyword;
 
   @Embedded
+  @Column(nullable = false)
   private FeedbackKeyword feedbackKeyword;
 
   @Builder

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/Feedback.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/Feedback.java
@@ -55,7 +55,7 @@ public class Feedback extends BaseEntity {
   private FeedbackKeyword feedbackKeyword;
 
   @Builder
-  public Feedback(Long id, Long userId, Long promptTemplateId, Mood mood, String userInput,
+  private Feedback(Long id, Long userId, Long promptTemplateId, Mood mood, String userInput,
       String prompt, String content, List<String> statusKeyword,
       List<String> feedbackKeyword) {
     this.id = id;

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/Feedback.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/Feedback.java
@@ -1,0 +1,70 @@
+package com.rouby.assistant.feedback.domain;
+
+import com.rouby.assistant.feedback.domain.enums.Mood;
+import com.rouby.assistant.feedback.domain.vo.FeedbackContent;
+import com.rouby.assistant.feedback.domain.vo.FeedbackKeyword;
+import com.rouby.assistant.feedback.domain.vo.StatusKeyword;
+import com.rouby.common.jpa.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Feedback extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Column(nullable = false)
+  private Long promptTemplateId;
+
+  @Enumerated(value = EnumType.STRING)
+  @Column(nullable = false)
+  private Mood mood;
+
+  @Column(nullable = false)
+  private String userInput;
+
+  @Embedded
+  private FeedbackContent feedbackContent;
+
+  @Embedded
+  private StatusKeyword statusKeyword;
+
+  @Embedded
+  private FeedbackKeyword feedbackKeyword;
+
+  @Builder
+  public Feedback(Long id, Long userId, Long promptTemplateId, Mood mood, String userInput,
+      String prompt, String content, List<String> statusKeyword,
+      List<String> feedbackKeyword) {
+    this.id = id;
+    this.userId = userId;
+    this.promptTemplateId = promptTemplateId;
+    this.mood = mood;
+    this.userInput = userInput;
+    this.feedbackContent = FeedbackContent.of(prompt, content);
+    this.statusKeyword = StatusKeyword.of(statusKeyword);
+    this.feedbackKeyword = FeedbackKeyword.of(feedbackKeyword);
+  }
+}

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/enums/Mood.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/enums/Mood.java
@@ -1,0 +1,14 @@
+package com.rouby.assistant.feedback.domain.enums;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public enum Mood {
+  TERRIBLE,
+  BAD,
+  SOSO,
+  GOOD,
+  EXCELLENT
+}

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/repository/FeedbackRepository.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/repository/FeedbackRepository.java
@@ -1,0 +1,8 @@
+package com.rouby.assistant.feedback.domain.repository;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public interface FeedbackRepository {}

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/vo/FeedbackContent.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/vo/FeedbackContent.java
@@ -1,0 +1,35 @@
+package com.rouby.assistant.feedback.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Embeddable
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedbackContent {
+
+  @Column(nullable = false)
+  private String prompt;
+
+  @Column(nullable = false)
+  private String content;
+
+  private FeedbackContent(String prompt, String content) {
+    this.prompt = prompt;
+    this.content = content;
+  }
+
+  public static FeedbackContent of(String prompt, String content){
+    return new FeedbackContent(prompt, content);
+  }
+}

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/vo/FeedbackKeyword.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/vo/FeedbackKeyword.java
@@ -27,7 +27,7 @@ public class FeedbackKeyword {
   private List<String> feedbackKeyword;
 
   private FeedbackKeyword(List<String> feedbackKeyword) {
-    this.feedbackKeyword = feedbackKeyword;
+    this.feedbackKeyword = new ArrayList<>(feedbackKeyword);
   }
 
   public static FeedbackKeyword of(List<String> feedbackKeyword) {

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/vo/FeedbackKeyword.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/vo/FeedbackKeyword.java
@@ -1,0 +1,41 @@
+package com.rouby.assistant.feedback.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Embeddable
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FeedbackKeyword {
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private List<String> feedbackKeyword;
+
+  private FeedbackKeyword(List<String> feedbackKeyword) {
+    this.feedbackKeyword = feedbackKeyword;
+  }
+
+  public static FeedbackKeyword of(List<String> feedbackKeyword) {
+    return new FeedbackKeyword(feedbackKeyword);
+  }
+
+  public List<String> getFeedbackKeyword() {
+    return List.copyOf(feedbackKeyword);
+  }
+
+}

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/vo/StatusKeyword.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/vo/StatusKeyword.java
@@ -1,0 +1,42 @@
+package com.rouby.assistant.feedback.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Embeddable
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StatusKeyword {
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private List<String> statusKeyword;
+
+  private StatusKeyword(List<String> statusKeyword) {
+    this.statusKeyword = new ArrayList<>(statusKeyword);
+  }
+
+  public static StatusKeyword of(List<String> statusKeyword){
+    return new StatusKeyword(statusKeyword);
+  }
+
+  //방어 복사(외부에서 컬렉션 수정 불가하게)
+  public List<String> getStatusKeyword() {
+    return List.copyOf(statusKeyword);
+  }
+
+}

--- a/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepository.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepository.java
@@ -1,0 +1,13 @@
+package com.rouby.assistant.feedback.infrastructure.persistence.jpa;
+
+import com.rouby.assistant.feedback.domain.Feedback;
+import com.rouby.assistant.feedback.domain.repository.FeedbackRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public interface FeedbackJpaRepository extends JpaRepository<Long, Feedback>,
+    FeedbackRepository,FeedbackJpaRepositoryCustom {}

--- a/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepository.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  *
  * @author : hanjihoon
  */
-public interface FeedbackJpaRepository extends JpaRepository<Long, Feedback>,
+public interface FeedbackJpaRepository extends JpaRepository<Feedback, Long>,
     FeedbackRepository,FeedbackJpaRepositoryCustom {}

--- a/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepositoryCustom.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.rouby.assistant.feedback.infrastructure.persistence.jpa;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public interface FeedbackJpaRepositoryCustom {}

--- a/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepositoryCustomImpl.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
  * @author : hanjihoon
  */
 @RequiredArgsConstructor
-public class FeedbackJpaRepositoryCustomImpl implements FeedbackJpaRepositoryCustom{
+public class FeedbackJpaRepositoryCustomImpl implements FeedbackJpaRepositoryCustom {
   
   private final JPAQueryFactory jpaQueryFactory;
 }

--- a/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepositoryCustomImpl.java
@@ -1,0 +1,15 @@
+package com.rouby.assistant.feedback.infrastructure.persistence.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@RequiredArgsConstructor
+public class FeedbackJpaRepositoryCustomImpl implements FeedbackJpaRepositoryCustom{
+  
+  private final JPAQueryFactory jpaQueryFactory;
+}

--- a/back/src/main/java/com/rouby/assistant/feedback/presentation/FeedbackController.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/presentation/FeedbackController.java
@@ -10,6 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
  * @author : hanjihoon
  */
 @RestController
-@RequestMapping("/api/v1/assistant/feedback")
+@RequestMapping("/api/v1/assistants/feedback")
 @RequiredArgsConstructor
 public class FeedbackController {}

--- a/back/src/main/java/com/rouby/assistant/feedback/presentation/FeedbackController.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/presentation/FeedbackController.java
@@ -1,0 +1,15 @@
+package com.rouby.assistant.feedback.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@RestController
+@RequestMapping("/api/v1/assistant/feedback")
+@RequiredArgsConstructor
+public class FeedbackController {}

--- a/back/src/main/java/com/rouby/assistant/recommendation/application/facade/RecommendationFacade.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/application/facade/RecommendationFacade.java
@@ -1,0 +1,13 @@
+package com.rouby.assistant.recommendation.application.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Service
+@RequiredArgsConstructor
+public class RecommendationFacade {}

--- a/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
@@ -35,6 +35,7 @@ public class Recommendation extends BaseEntity {
   private Long promptTemplateId;
 
   @Embedded
+  @Column(nullable = false)
   private RecommendationContent recommendationContent;
 
   @Builder

--- a/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
@@ -1,0 +1,48 @@
+package com.rouby.assistant.recommendation.domain;
+
+import com.rouby.assistant.briefing.domain.vo.BriefingContent;
+import com.rouby.assistant.recommendation.domain.vo.RecommendationContent;
+import com.rouby.common.jpa.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recommendation extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Column(nullable = false)
+  private Long promptTemplateId;
+
+  @Embedded
+  private RecommendationContent recommendationContent;
+
+  @Builder
+  public Recommendation(Long id, Long userId, Long promptTemplateId,
+      String prompt, String recommendationResponse) {
+    this.id = id;
+    this.userId = userId;
+    this.promptTemplateId = promptTemplateId;
+    this.recommendationContent = RecommendationContent.of(prompt, recommendationResponse);
+  }
+}

--- a/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
@@ -34,7 +34,6 @@ public class Recommendation extends BaseEntity {
   private Long promptTemplateId;
 
   @Embedded
-  @Column(nullable = false)
   private RecommendationContent recommendationContent;
 
   @Builder

--- a/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
@@ -1,6 +1,5 @@
 package com.rouby.assistant.recommendation.domain;
 
-import com.rouby.assistant.briefing.domain.vo.BriefingContent;
 import com.rouby.assistant.recommendation.domain.vo.RecommendationContent;
 import com.rouby.common.jpa.BaseEntity;
 import jakarta.persistence.Column;

--- a/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/domain/Recommendation.java
@@ -38,7 +38,7 @@ public class Recommendation extends BaseEntity {
   private RecommendationContent recommendationContent;
 
   @Builder
-  public Recommendation(Long id, Long userId, Long promptTemplateId,
+  private Recommendation(Long id, Long userId, Long promptTemplateId,
       String prompt, String recommendationResponse) {
     this.id = id;
     this.userId = userId;

--- a/back/src/main/java/com/rouby/assistant/recommendation/domain/repository/RecommendationRepository.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/domain/repository/RecommendationRepository.java
@@ -1,0 +1,8 @@
+package com.rouby.assistant.recommendation.domain.repository;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public interface RecommendationRepository {}

--- a/back/src/main/java/com/rouby/assistant/recommendation/domain/vo/RecommendationContent.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/domain/vo/RecommendationContent.java
@@ -1,0 +1,37 @@
+package com.rouby.assistant.recommendation.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@Embeddable
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecommendationContent {
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String prompt;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String recommendationResponse;
+
+  private RecommendationContent(String prompt, String recommendationResponse) {
+    this.prompt = prompt;
+    this.recommendationResponse = recommendationResponse;
+  }
+
+  public static RecommendationContent of(String prompt, String recommendationResponse){
+    return new RecommendationContent(prompt, recommendationResponse);
+  }
+}
+
+

--- a/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepository.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepository.java
@@ -1,0 +1,13 @@
+package com.rouby.assistant.recommendation.infrastructure.persistence.jpa;
+
+import com.rouby.assistant.recommendation.domain.Recommendation;
+import com.rouby.assistant.recommendation.domain.repository.RecommendationRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public interface RecommendationJpaRepository extends JpaRepository<Long, Recommendation>,
+    RecommendationRepository,RecommendationJpaRepositoryCustom {}

--- a/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepository.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
  *
  * @author : hanjihoon
  */
-public interface RecommendationJpaRepository extends JpaRepository<Long, Recommendation>,
+public interface RecommendationJpaRepository extends JpaRepository<Recommendation, Long>,
     RecommendationRepository,RecommendationJpaRepositoryCustom {}

--- a/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepository.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepository.java
@@ -10,4 +10,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @author : hanjihoon
  */
 public interface RecommendationJpaRepository extends JpaRepository<Recommendation, Long>,
-    RecommendationRepository,RecommendationJpaRepositoryCustom {}
+    RecommendationRepository, RecommendationJpaRepositoryCustom {}

--- a/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepositoryCustom.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.rouby.assistant.recommendation.infrastructure.persistence.jpa;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+public interface RecommendationJpaRepositoryCustom {}

--- a/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepositoryCustomImpl.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
  * @author : hanjihoon
  */
 @RequiredArgsConstructor
-public class RecommendationJpaRepositoryCustomImpl implements RecommendationJpaRepositoryCustom{
+public class RecommendationJpaRepositoryCustomImpl implements RecommendationJpaRepositoryCustom {
 
   private final JPAQueryFactory jpaQueryFactory;
 }

--- a/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/infrastructure/persistence/jpa/RecommendationJpaRepositoryCustomImpl.java
@@ -1,0 +1,15 @@
+package com.rouby.assistant.recommendation.infrastructure.persistence.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@RequiredArgsConstructor
+public class RecommendationJpaRepositoryCustomImpl implements RecommendationJpaRepositoryCustom{
+
+  private final JPAQueryFactory jpaQueryFactory;
+}

--- a/back/src/main/java/com/rouby/assistant/recommendation/presentation/RecommendationController.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/presentation/RecommendationController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author : hanjihoon
  */
 @RestController
-@RequestMapping("/api/v1/assistant/recommendation")
+@RequestMapping("/api/v1/assistants/recommendations")
 @RequiredArgsConstructor
 public class RecommendationController {
 

--- a/back/src/main/java/com/rouby/assistant/recommendation/presentation/RecommendationController.java
+++ b/back/src/main/java/com/rouby/assistant/recommendation/presentation/RecommendationController.java
@@ -1,0 +1,17 @@
+package com.rouby.assistant.recommendation.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @Date : 2025. 07. 07.
+ *
+ * @author : hanjihoon
+ */
+@RestController
+@RequestMapping("/api/v1/assistant/recommendation")
+@RequiredArgsConstructor
+public class RecommendationController {
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #60 

## 변경 타입
- [x] 신규 기능 추가/수정


## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.

## 코멘트
- 각각 도메인별로 나누는게 좋을 것 같아서 미리 말씀 드린대로 나누어서 구성했는데 과한듯 싶다가도 그래도 분리하니 뭔가 편안해서 좋은데 별로 같으시면 말씀 해주세요...!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 브리핑, 피드백, 추천에 대한 도메인 엔티티 및 JPA 저장소가 추가되었습니다.
  * 브리핑, 피드백, 추천 각각에 대해 REST API 컨트롤러가 `/api/v1/assistant/feedback` 및 `/api/v1/assistant/recommendation` 경로로 생성되었습니다.
  * 피드백에 대한 기분(Mood) 선택, 키워드, 내용 등 다양한 구조화된 데이터 입력이 지원됩니다.
  * 각 도메인별로 서비스 및 저장소 계층이 기본적으로 구성되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->