### PR TITLE
[#98][fe][user] 비밀번호 변경(마이페이지) 화면 추가

### DIFF
--- a/front/src/api/axios.js
+++ b/front/src/api/axios.js
@@ -14,7 +14,7 @@ instance.interceptors.request.use(
   (config) => {
     const token = getStoredToken()
     if (token) {
-      config.headers.Authorization = `${token}`
+      config.headers.Authorization = "Bearer " + `${token}`
     }
     return config
   },

--- a/front/src/api/axios.js
+++ b/front/src/api/axios.js
@@ -1,8 +1,5 @@
 import axios from 'axios'
-
-function getAccessToken() {
-  return localStorage.getItem('access_token')
-}
+import { getStoredToken } from '@/features/auth/storeToken.js'
 
 const instance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api',
@@ -15,9 +12,9 @@ const instance = axios.create({
 // 요청 인터셉터 – Authorization 헤더 자동 추가
 instance.interceptors.request.use(
   (config) => {
-    const token = getAccessToken()
+    const token = getStoredToken()
     if (token) {
-      config.headers.Authorization = `Bearer ${token}`
+      config.headers.Authorization = `${token}`
     }
     return config
   },

--- a/front/src/features/auth/api.js
+++ b/front/src/features/auth/api.js
@@ -11,3 +11,7 @@ export const verifyEmail = (payload) => {
 export const signup = (payload) => {
   return axios.post('/api/v1/users', payload)
 }
+
+export const myPageResetPassword = (payload) => {
+  return axios.patch('/v1/users/password/reset', payload)
+}

--- a/front/src/features/auth/api.js
+++ b/front/src/features/auth/api.js
@@ -11,7 +11,3 @@ export const verifyEmail = (payload) => {
 export const signup = (payload) => {
   return axios.post('/api/v1/users', payload)
 }
-
-export const myPageResetPassword = (payload) => {
-  return axios.patch('/v1/users/password/reset', payload)
-}

--- a/front/src/features/auth/authService.js
+++ b/front/src/features/auth/authService.js
@@ -3,12 +3,11 @@ import {
   requestEmailVerification as requestEmailVerificationApi,
   verifyEmail as verifyEmailApi,
   signup as signupApi,
-  myPageResetPassword as myPageResetPasswordApi
 } from './api.js'
 import {
   toSignupPayload,
   toEmailVerificationPayload,
-  toVerifyCodePayload, toMyPageResetPasswordPayload
+  toVerifyCodePayload
 } from './dto.js'
 
 export const requestEmailVerification = wrapApi(
@@ -35,10 +34,4 @@ export const signup = wrapApi(
   },
 )
 
-export const myPageResetPassword = wrapApi(
-  (form) => myPageResetPasswordApi(toMyPageResetPasswordPayload(form)).then(() => ({ ok: true })),
-  {
-    fieldMessages: {},
-    fallbackMessage: '비밀번호 변경에 실패했습니다.',
-  },
-)
+

--- a/front/src/features/auth/authService.js
+++ b/front/src/features/auth/authService.js
@@ -3,11 +3,12 @@ import {
   requestEmailVerification as requestEmailVerificationApi,
   verifyEmail as verifyEmailApi,
   signup as signupApi,
+  myPageResetPassword as myPageResetPasswordApi
 } from './api.js'
 import {
   toSignupPayload,
   toEmailVerificationPayload,
-  toVerifyCodePayload
+  toVerifyCodePayload, toMyPageResetPasswordPayload
 } from './dto.js'
 
 export const requestEmailVerification = wrapApi(
@@ -31,5 +32,13 @@ export const signup = wrapApi(
   {
     fieldMessages: {},
     fallbackMessage: '가입에 실패했습니다.',
+  },
+)
+
+export const myPageResetPassword = wrapApi(
+  (form) => myPageResetPasswordApi(toMyPageResetPasswordPayload(form)).then(() => ({ ok: true })),
+  {
+    fieldMessages: {},
+    fallbackMessage: '비밀번호 변경에 실패했습니다.',
   },
 )

--- a/front/src/features/auth/dto.js
+++ b/front/src/features/auth/dto.js
@@ -17,3 +17,11 @@ export function toVerifyCodePayload(email, code) {
     code: code?.trim()
   };
 }
+
+export function toMyPageResetPasswordPayload(form) {
+  return {
+    currentPassword: form.password,
+    newPassword: form.newPassword,
+    token: form.token?.trim()
+  };
+}

--- a/front/src/features/auth/dto.js
+++ b/front/src/features/auth/dto.js
@@ -18,10 +18,4 @@ export function toVerifyCodePayload(email, code) {
   };
 }
 
-export function toMyPageResetPasswordPayload(form) {
-  return {
-    currentPassword: form.password,
-    newPassword: form.newPassword,
-    token: form.token?.trim()
-  };
-}
+

--- a/front/src/features/auth/useSignupForm.js
+++ b/front/src/features/auth/useSignupForm.js
@@ -3,7 +3,12 @@ import { useRouter } from 'vue-router'
 import { useTimer } from '@/utils/timerUtils.js'
 import { buildErrorCleaner, buildFieldValidator } from '@/utils/formUtils.js'
 
-import { requestEmailVerification, signup, verifyEmailCode } from './authService.js'
+import {
+  myPageResetPassword,
+  requestEmailVerification,
+  signup,
+  verifyEmailCode
+} from './authService.js'
 
 import {
   validateEmail,
@@ -20,6 +25,7 @@ export function useSignupForm() {
     verificationCode: '',
     password: '',
     passwordConfirm: '',
+    newPassword: '',
     isEmailVerified: false,
     isVerificationStep: false,
   })
@@ -29,6 +35,7 @@ export function useSignupForm() {
     verificationCode: '',
     password: '',
     passwordConfirm: '',
+    apiResult: '',
   })
 
   const loading = reactive({
@@ -51,6 +58,9 @@ export function useSignupForm() {
   const validatePasswordField = () => validateField(validatePassword, 'password', form.password)
   const validatePasswordConfirmField = () =>
     validateField(validatePasswordConfirm, 'passwordConfirm', form.password, form.passwordConfirm)
+
+  const validateNewPasswordConfirmField = () =>
+    validateField(validatePasswordConfirm, 'passwordConfirm', form.newPassword, form.passwordConfirm)
 
   const clearErrors = buildErrorCleaner(errors, [
     { field: 'email', get: (state) => state.email },
@@ -140,6 +150,23 @@ export function useSignupForm() {
     await requestVerification()
   }
 
+  const sendMyPageResetPassword  = async () => {
+    validatePasswordField(form)
+    validateNewPasswordConfirmField(form)
+    try {
+      const success = await myPageResetPassword(form)
+      if (success) {
+        //변경완료
+        await router.push('/auth/login')
+      }
+    } catch (err) {
+      if (err.fieldErrors) {
+        Object.assign(errors, err.fieldErrors)
+      } else {
+        errors.apiResult = '비밀번호 변경에 실패했습니다.'
+      }
+    }
+  }
   window.testSignup = {
     // 1. 폼 데이터 자동 입력
     fill: () => {
@@ -208,5 +235,7 @@ export function useSignupForm() {
     validateEmailField,
     validatePasswordField,
     validatePasswordConfirmField,
+    validateNewPasswordConfirmField,
+    sendMyPageResetPassword,
   }
 }

--- a/front/src/features/schedule/dto.js
+++ b/front/src/features/schedule/dto.js
@@ -37,12 +37,12 @@ export function toCreateSchedulePayload(form) {
     startTime: form.allDay ? MIDNIGHT : toTime(form.start),
     endDate: form.allDay ? toDate(getNxtDate(form.end)) : toDate(form.end),
     endTime: form.allDay ? MIDNIGHT : toTime(form.end),
-    recurrenceRule: !form.reapet
+    recurrenceRule: !form.repeat
       ? null
       : {
-          freq: form.repeat !== BIWEEKLY ? form.reapet : WEEKELY,
+          freq: form.repeat !== BIWEEKLY ? form.repeat : WEEKELY,
           byDay: weekdays.length < 1 ? null : weekdays.map((d) => d).join(','),
-          interval: !form.reapet ? null : form.repeat !== BIWEEKLY ? 1 : 2,
+          interval: !form.repeat ? null : form.repeat !== BIWEEKLY ? 1 : 2,
           until: '2100-01-01T00:00Z', // null로 하거나, 현재 화면으로 선택 불가
         },
   }

--- a/front/src/features/user/api.js
+++ b/front/src/features/user/api.js
@@ -1,0 +1,5 @@
+import axios from '@/api/axios.js'
+
+export const myPageResetPassword = (payload) => {
+  return axios.patch('/v1/users/password/reset', payload)
+}

--- a/front/src/features/user/components/MyPageResetPasswordForm.vue
+++ b/front/src/features/user/components/MyPageResetPasswordForm.vue
@@ -1,69 +1,84 @@
 <template>
-  <form @submit.prevent="sendMyPageResetPassword" class="p-6 space-y-4">
-  <!-- 비밀번호 필드 -->
-  <div class="space-y-2">
-    <BaseInput
-      v-model="form.password"
-      label="기존 비밀번호 확인"
-      type="password"
-      placeholder="비밀번호를 입력하세요"
-      :error="errors.password"
-      label-class="text-auth-label-color"
-      class="placeholder-placeholder-pink-color"
-    />
-    <p class="text-xs text-gray-500 mt-[-0.5rem](-8px) mx-2">영문 대·소문자/숫자/특수문자 중 2가지 이상 조합, 8자~32자</p>
-    <FieldError :message="errors.password" />
-  </div>
+  <form @submit.prevent="sendResetPassword" class="p-6 space-y-4">
+    <!-- 기존 비밀번호 -->
+    <div class="space-y-2">
+      <BaseInput
+        v-model="form.password"
+        label="기존 비밀번호 확인"
+        type="password"
+        placeholder="비밀번호를 입력하세요"
+        :error="errors.password"
+        label-class="text-auth-label-color"
+        class="placeholder-placeholder-pink-color"
+        @blur="validatePasswordField"
+      />
+      <FieldError :message="errors.password" />
+    </div>
 
-  <div class="space-y-2">
-    <BaseInput
-      v-model="form.newPassword"
-      label="변경할 비밀번호"
-      type="password"
-      placeholder="비밀번호를 입력하세요"
-      :error="errors.password"
-      label-class="text-auth-label-color"
-      class="placeholder-placeholder-pink-color"
-      @keyup="validatePasswordField"
-    />
-    <p class="text-xs text-gray-500 mt-[-0.5rem](-8px) mx-2">영문 대·소문자/숫자/특수문자 중 2가지 이상 조합, 8자~32자</p>
-    <FieldError :message="errors.password" />
-  </div>
+    <!-- 새 비밀번호 -->
+    <div class="space-y-2">
+      <BaseInput
+        v-model="form.newPassword"
+        label="변경할 비밀번호"
+        type="password"
+        placeholder="비밀번호를 입력하세요"
+        :error="errors.password"
+        label-class="text-auth-label-color"
+        class="placeholder-placeholder-pink-color"
+        @blur="validatePasswordField"
+      />
+      <p class="text-xs text-gray-500 mt-[-0.5rem] mx-2">
+        영문 대·소문자/숫자/특수문자 중 2가지 이상 조합, 8자~32자
+      </p>
+      <FieldError :message="errors.password" />
+    </div>
 
-  <div class="space-y-2">
-    <BaseInput
-      v-model="form.passwordConfirm"
-      label="비밀번호 확인"
-      type="password"
-      placeholder="비밀번호를 다시 입력하세요"
-      :error="errors.passwordConfirm"
-      @blur="validateNewPasswordConfirmField"
-      label-class="text-auth-label-color"
-      class="placeholder-placeholder-pink-color"
-    />
-    <FieldError :message="errors.passwordConfirm" />
-  </div>
+    <!-- 비밀번호 확인 -->
+    <div class="space-y-2">
+      <BaseInput
+        v-model="form.passwordConfirm"
+        label="비밀번호 확인"
+        type="password"
+        placeholder="비밀번호를 다시 입력하세요"
+        :error="errors.passwordConfirm"
+        label-class="text-auth-label-color"
+        class="placeholder-placeholder-pink-color"
+        @blur="validatePasswordConfirmField"
+      />
+      <FieldError :message="errors.passwordConfirm" />
+    </div>
+
+    <!-- API 에러 -->
     <FieldError :message="errors.apiResult" />
-  <!-- 변경하기 버튼 -->
-  <BaseButton
-    type="submit"
-    class="w-full font-medium transition-colors"
-  > 변경하기
-  </BaseButton>
+    <!-- 성공 메시지 추가 -->
+    <p v-if="successMessage.message" class="text-green-600 text-sm font-medium text-center mb-[-0.5rem]">
+      {{ successMessage.message }}
+    </p>
+
+    <!-- 제출 버튼 -->
+    <BaseButton
+      type="submit"
+      class="w-full font-medium transition-colors"
+      :loading="loading.reset"
+    >
+      변경하기
+    </BaseButton>
   </form>
 </template>
 
 <script setup>
-import { useSignupForm } from '@/features/auth/useSignupForm.js'
+import { usePasswordForm } from '@/features/user/usePasswordForm.js'
 import BaseInput from '@/components/common/BaseInput.vue'
 import FieldError from '@/components/common/FieldError.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
+
 const {
   form,
   errors,
+  loading,
+  successMessage,
   validatePasswordField,
-  sendMyPageResetPassword,
-  validateNewPasswordConfirmField,
-} = useSignupForm()
+  validatePasswordConfirmField,
+  sendResetPassword
+} = usePasswordForm()
 </script>
-

--- a/front/src/features/user/components/MyPageResetPasswordForm.vue
+++ b/front/src/features/user/components/MyPageResetPasswordForm.vue
@@ -1,0 +1,69 @@
+<template>
+  <form @submit.prevent="sendMyPageResetPassword" class="p-6 space-y-4">
+  <!-- 비밀번호 필드 -->
+  <div class="space-y-2">
+    <BaseInput
+      v-model="form.password"
+      label="기존 비밀번호 확인"
+      type="password"
+      placeholder="비밀번호를 입력하세요"
+      :error="errors.password"
+      label-class="text-auth-label-color"
+      class="placeholder-placeholder-pink-color"
+    />
+    <p class="text-xs text-gray-500 mt-[-0.5rem](-8px) mx-2">영문 대·소문자/숫자/특수문자 중 2가지 이상 조합, 8자~32자</p>
+    <FieldError :message="errors.password" />
+  </div>
+
+  <div class="space-y-2">
+    <BaseInput
+      v-model="form.newPassword"
+      label="변경할 비밀번호"
+      type="password"
+      placeholder="비밀번호를 입력하세요"
+      :error="errors.password"
+      label-class="text-auth-label-color"
+      class="placeholder-placeholder-pink-color"
+      @keyup="validatePasswordField"
+    />
+    <p class="text-xs text-gray-500 mt-[-0.5rem](-8px) mx-2">영문 대·소문자/숫자/특수문자 중 2가지 이상 조합, 8자~32자</p>
+    <FieldError :message="errors.password" />
+  </div>
+
+  <div class="space-y-2">
+    <BaseInput
+      v-model="form.passwordConfirm"
+      label="비밀번호 확인"
+      type="password"
+      placeholder="비밀번호를 다시 입력하세요"
+      :error="errors.passwordConfirm"
+      @blur="validateNewPasswordConfirmField"
+      label-class="text-auth-label-color"
+      class="placeholder-placeholder-pink-color"
+    />
+    <FieldError :message="errors.passwordConfirm" />
+  </div>
+    <FieldError :message="errors.apiResult" />
+  <!-- 변경하기 버튼 -->
+  <BaseButton
+    type="submit"
+    class="w-full font-medium transition-colors"
+  > 변경하기
+  </BaseButton>
+  </form>
+</template>
+
+<script setup>
+import { useSignupForm } from '@/features/auth/useSignupForm.js'
+import BaseInput from '@/components/common/BaseInput.vue'
+import FieldError from '@/components/common/FieldError.vue'
+import BaseButton from '@/components/common/BaseButton.vue'
+const {
+  form,
+  errors,
+  validatePasswordField,
+  sendMyPageResetPassword,
+  validateNewPasswordConfirmField,
+} = useSignupForm()
+</script>
+

--- a/front/src/features/user/dto.js
+++ b/front/src/features/user/dto.js
@@ -1,0 +1,7 @@
+export function toMyPageResetPasswordPayload(form) {
+  return {
+    currentPassword: form.password,
+    newPassword: form.newPassword,
+    token: form.token?.trim()
+  };
+}

--- a/front/src/features/user/usePasswordForm.js
+++ b/front/src/features/user/usePasswordForm.js
@@ -1,0 +1,80 @@
+import { reactive } from 'vue'
+import { useRouter } from 'vue-router'
+import { buildErrorCleaner, buildFieldValidator } from '@/utils/formUtils.js'
+import { myPageResetPassword } from '@/features/user/userService.js'
+import {
+  validatePassword,
+  validatePasswordConfirm,
+} from '@/features/auth/validations.js'
+
+export function usePasswordForm() {
+  const router = useRouter()
+
+  const form = reactive({
+    password: '',
+    passwordConfirm: '',
+    newPassword: '',
+  })
+
+  const errors = reactive({
+    password: '',
+    passwordConfirm: '',
+    apiResult: '',
+  })
+
+  const loading = reactive({
+    reset: false,
+  })
+
+  const successMessage = reactive({
+    message: '',
+  })
+
+  const validateField = buildFieldValidator(errors)
+
+  const validatePasswordField = () =>
+    validateField(validatePassword, 'password', form.password)
+
+  const validatePasswordConfirmField = () =>
+    validateField(validatePasswordConfirm, 'passwordConfirm', form.newPassword, form.passwordConfirm)
+
+  const clearErrors = buildErrorCleaner(errors, [
+    { field: 'password', get: (state) => state.password },
+    { field: 'passwordConfirm', get: (state) => state.passwordConfirm },
+  ])
+
+  const sendResetPassword = async () => {
+    const isPasswordValid = validatePasswordField()
+    const isPasswordConfirmValid = validatePasswordConfirmField()
+
+    if (!isPasswordValid || !isPasswordConfirmValid) return
+
+    loading.reset = true
+    try {
+      const success = await myPageResetPassword(form)
+      if (success) {
+        successMessage.message = '비밀번호가 성공적으로 변경되었습니다.'
+        // await router.push('/auth/login')
+      }
+    } catch (err) {
+      if (err.fieldErrors) {
+        Object.assign(errors, err.fieldErrors)
+      } else {
+        errors.apiResult = '비밀번호 변경에 실패했습니다.'
+      }
+    } finally {
+      loading.reset = false
+    }
+  }
+
+
+  return {
+    form,
+    errors,
+    loading,
+    successMessage,
+    validatePasswordField,
+    validatePasswordConfirmField,
+    sendResetPassword,
+  }
+}

--- a/front/src/features/user/userService.js
+++ b/front/src/features/user/userService.js
@@ -1,0 +1,11 @@
+import { wrapApi } from '@/utils/errorUtils.js'
+import { myPageResetPassword as myPageResetPasswordApi } from '@/features/user/api.js'
+import { toMyPageResetPasswordPayload } from '@/features/user/dto.js'
+
+export const myPageResetPassword = wrapApi(
+  (form) => myPageResetPasswordApi(toMyPageResetPasswordPayload(form)).then(() => ({ ok: true })),
+  {
+    fieldMessages: {},
+    fallbackMessage: '비밀번호 변경에 실패했습니다.',
+  },
+)

--- a/front/src/features/user/views/MyPageResetPasswordView.vue
+++ b/front/src/features/user/views/MyPageResetPasswordView.vue
@@ -1,0 +1,22 @@
+<template>
+
+  <div class="main-container">
+    <div class="sub-main-container">
+      <div class="text-center">
+        <h1 class="text-2xl font-bold text-main-color mb-2">비밀번호 변경</h1>
+      </div>
+      <!-- Lock Icon -->
+      <div class="lock-container flex justify-center items-center my-6">
+        <figure>
+          <img :src="PasswordLockIcon" alt="패스워드 잠금 아이콘" />
+        </figure>
+      </div>
+      <!-- 비밀번호 변경 폼 -->
+      <MyPageResetPasswordForm />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import MyPageResetPasswordForm from '@/features/user/components/MyPageResetPasswordForm.vue'
+</script>

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -65,6 +65,17 @@ const router = createRouter({
         },
       ]
     },
+    {
+      path: '/user',
+      component: () => import('@/layouts/DefaultLayout.vue'),
+      children: [
+        {
+          path: '/password/reset',
+          name: 'password-reset',
+          component: () => import('@/features/user/views/MyPageResetPasswordView.vue'),
+        },
+      ],
+    },
 
   ],
 })

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -70,7 +70,7 @@ const router = createRouter({
       component: () => import('@/layouts/DefaultLayout.vue'),
       children: [
         {
-          path: '/password/reset',
+          path: 'password/reset',
           name: 'password-reset',
           component: () => import('@/features/user/views/MyPageResetPasswordView.vue'),
         },

--- a/front/src/utils/errorUtils.js
+++ b/front/src/utils/errorUtils.js
@@ -33,8 +33,7 @@ export function createApiError(err, {
 export function wrapApi(apiFn, options) {
   return async (...args) => {
     try {
-      const res = await apiFn(...args);
-      return res.data;
+      return await apiFn(...args)
     } catch (err) {
       throw createApiError(err, options);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #98 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 비밀번호 변경 화면(마이페이지) 추가
  - [x] 오타 수정 및 wrapApi기능 수정
  - [x] 헤더 토큰 자동 입력 수정
  
## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- 화면 아이콘은 #43번 이슈에 넣어 놔서 추가 안 했습니다.
비밀번호 변경(마이페이지)화면
<img width="1093" height="859" alt="image" src="https://github.com/user-attachments/assets/99a0252a-c6ce-4c48-b1fd-0dc6d06f0ddc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 비밀번호 재설정 페이지 및 폼이 추가되어, 사용자가 현재 비밀번호와 새 비밀번호를 입력해 비밀번호를 변경할 수 있습니다.
  * `/password/reset` 경로에서 비밀번호 변경 기능을 이용할 수 있습니다.

* **버그 수정**
  * 일정 생성 시 반복 설정 관련 오타(`reapet` → `repeat`)가 수정되어 반복 일정 등록이 정상적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->