### PR TITLE
[#62][be][user] 건강상태, 현재상태 추가 및 자료구조 변경

### DIFF
--- a/back/src/main/java/com/rouby/user/application/exception/UserErrorCode.java
+++ b/back/src/main/java/com/rouby/user/application/exception/UserErrorCode.java
@@ -6,9 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 /**
- * @Date : 2025. 07. 08.
- *
  * @author : hanjihoon
+ * @Date : 2025. 07. 08.
  */
 @Getter
 @RequiredArgsConstructor
@@ -22,7 +21,9 @@ public enum UserErrorCode implements ErrorCode {
   INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", "INVALID_PASSWORD", HttpStatus.UNAUTHORIZED),
   USER_NOT_FOUND("존재하지 않는 유저입니다.", "USER_NOT_FOUND", HttpStatus.NOT_FOUND),
   PASSWORD_TOKEN_EXPIRED("비밀번호 재설정 토큰이 만료되었습니다.", "PASSWORD_TOKEN_EXPIRED",
-      HttpStatus.UNAUTHORIZED);
+      HttpStatus.UNAUTHORIZED),
+  EMAIL_NOT_VERIFIED("이메일 인증이 필요합니다. 인증 후 이용해주세요.", "EMAIL_NOT_VERIFIED", HttpStatus.UNAUTHORIZED),
+  ;
 
   private final String message;
   private final String code;

--- a/back/src/main/java/com/rouby/user/application/service/UserWriteService.java
+++ b/back/src/main/java/com/rouby/user/application/service/UserWriteService.java
@@ -34,8 +34,8 @@ public class UserWriteService {
 
   @Transactional
   public void create(CreateUserCommand command) {
-//    ensureEmailNotTaken(command.email());
-//    ensureEmailVerified(command.email());
+    ensureEmailNotTaken(command.email());
+    ensureEmailVerified(command.email());
 
     User user = User.create(command.email(), command.password(), passwordEncoder);
     userRepository.save(user);

--- a/back/src/main/java/com/rouby/user/application/service/UserWriteService.java
+++ b/back/src/main/java/com/rouby/user/application/service/UserWriteService.java
@@ -1,6 +1,7 @@
 package com.rouby.user.application.service;
 
 import static com.rouby.user.application.exception.UserErrorCode.DUPLICATE_EMAIL;
+import static com.rouby.user.application.exception.UserErrorCode.EMAIL_NOT_VERIFIED;
 import static com.rouby.user.application.exception.UserErrorCode.INVALID_EMAIL_VERIFICATION;
 import static com.rouby.user.application.exception.UserErrorCode.PASSWORD_TOKEN_EXPIRED;
 import static com.rouby.user.application.exception.UserErrorCode.USER_NOT_FOUND;
@@ -33,8 +34,8 @@ public class UserWriteService {
 
   @Transactional
   public void create(CreateUserCommand command) {
-    ensureEmailNotTaken(command.email());
-    ensureEmailVerified(command.email());
+//    ensureEmailNotTaken(command.email());
+//    ensureEmailVerified(command.email());
 
     User user = User.create(command.email(), command.password(), passwordEncoder);
     userRepository.save(user);
@@ -49,10 +50,10 @@ public class UserWriteService {
 
   private void ensureEmailVerified(String email) {
     VerificationEmailCode code = verificationEmailCodeStorage.findByEmail(email)
-            .orElseThrow(() -> UserException.from(INVALID_EMAIL_VERIFICATION));
+            .orElseThrow(() -> UserException.from(EMAIL_NOT_VERIFIED));
 
     if(!code.isVerified()) {
-      throw UserException.from(INVALID_EMAIL_VERIFICATION);
+      throw UserException.from(EMAIL_NOT_VERIFIED);
     }
   }
 

--- a/back/src/main/java/com/rouby/user/domain/entity/CommunicationTone.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/CommunicationTone.java
@@ -3,7 +3,7 @@ package com.rouby.user.domain.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.Getter;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -21,11 +21,11 @@ public class CommunicationTone implements Serializable {
   }
 
   private CommunicationTone(Set<String> communicationTone) {
-    this.roubyCommunicationTone = new HashSet<>(communicationTone);
+    this.roubyCommunicationTone = new LinkedHashSet<>(communicationTone);
   }
 
   public static CommunicationTone empty(){
-    return new CommunicationTone(new HashSet<>());
+    return new CommunicationTone(new LinkedHashSet<>());
   }
 
   public static CommunicationTone of(Set<String> communicationTone) {

--- a/back/src/main/java/com/rouby/user/domain/entity/CommunicationTone.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/CommunicationTone.java
@@ -17,18 +17,14 @@ public class CommunicationTone implements Serializable {
   @Column(columnDefinition = "jsonb")
   private Set<String> roubyCommunicationTone;
 
-  protected CommunicationTone() {
+  public static CommunicationTone empty(){
+    return new CommunicationTone(new LinkedHashSet<>());
   }
 
   private CommunicationTone(Set<String> communicationTone) {
     this.roubyCommunicationTone = new LinkedHashSet<>(communicationTone);
   }
 
-  public static CommunicationTone empty(){
-    return new CommunicationTone(new LinkedHashSet<>());
-  }
-
-  public static CommunicationTone of(Set<String> communicationTone) {
-    return new CommunicationTone(communicationTone);
+  protected CommunicationTone() {
   }
 }

--- a/back/src/main/java/com/rouby/user/domain/entity/CommunicationTone.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/CommunicationTone.java
@@ -3,8 +3,8 @@ package com.rouby.user.domain.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Getter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -15,20 +15,20 @@ public class CommunicationTone implements Serializable {
 
   @JdbcTypeCode(SqlTypes.JSON)
   @Column(columnDefinition = "jsonb")
-  private List<String> roubyCommunicationTone;
+  private Set<String> roubyCommunicationTone;
 
   protected CommunicationTone() {
   }
 
-  private CommunicationTone(List<String> communicationTone) {
-    this.roubyCommunicationTone = new ArrayList<>(communicationTone);
+  private CommunicationTone(Set<String> communicationTone) {
+    this.roubyCommunicationTone = new HashSet<>(communicationTone);
   }
 
   public static CommunicationTone empty(){
-    return new CommunicationTone(new ArrayList<>());
+    return new CommunicationTone(new HashSet<>());
   }
 
-  public static CommunicationTone of(List<String> communicationTone) {
+  public static CommunicationTone of(Set<String> communicationTone) {
     return new CommunicationTone(communicationTone);
   }
 }

--- a/back/src/main/java/com/rouby/user/domain/entity/CurrentStatusKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/CurrentStatusKeywords.java
@@ -1,0 +1,34 @@
+package com.rouby.user.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@Embeddable
+public class CurrentStatusKeywords implements Serializable {
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb")
+  private Set<String> currentStatusKeywords;
+
+  public static CurrentStatusKeywords empty(){
+    return new CurrentStatusKeywords(new HashSet<>());
+  }
+
+  public static CurrentStatusKeywords of(Set<String> keywords) {
+    return new CurrentStatusKeywords(keywords);
+  }
+
+  private CurrentStatusKeywords(Set<String> currentStatusKeywords) {
+    this.currentStatusKeywords = new HashSet<>(currentStatusKeywords);
+  }
+
+  protected CurrentStatusKeywords() {
+  }
+}

--- a/back/src/main/java/com/rouby/user/domain/entity/CurrentStatusKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/CurrentStatusKeywords.java
@@ -3,7 +3,7 @@ package com.rouby.user.domain.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.Getter;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -18,7 +18,7 @@ public class CurrentStatusKeywords implements Serializable {
   private Set<String> currentStatusKeywords;
 
   public static CurrentStatusKeywords empty(){
-    return new CurrentStatusKeywords(new HashSet<>());
+    return new CurrentStatusKeywords(new LinkedHashSet<>());
   }
 
   public static CurrentStatusKeywords of(Set<String> keywords) {
@@ -26,7 +26,7 @@ public class CurrentStatusKeywords implements Serializable {
   }
 
   private CurrentStatusKeywords(Set<String> currentStatusKeywords) {
-    this.currentStatusKeywords = new HashSet<>(currentStatusKeywords);
+    this.currentStatusKeywords = new LinkedHashSet<>(currentStatusKeywords);
   }
 
   protected CurrentStatusKeywords() {

--- a/back/src/main/java/com/rouby/user/domain/entity/CurrentStatusKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/CurrentStatusKeywords.java
@@ -21,10 +21,6 @@ public class CurrentStatusKeywords implements Serializable {
     return new CurrentStatusKeywords(new LinkedHashSet<>());
   }
 
-  public static CurrentStatusKeywords of(Set<String> keywords) {
-    return new CurrentStatusKeywords(keywords);
-  }
-
   private CurrentStatusKeywords(Set<String> currentStatusKeywords) {
     this.currentStatusKeywords = new LinkedHashSet<>(currentStatusKeywords);
   }

--- a/back/src/main/java/com/rouby/user/domain/entity/HealthStatusKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/HealthStatusKeywords.java
@@ -21,10 +21,6 @@ public class HealthStatusKeywords implements Serializable {
     return new HealthStatusKeywords(new LinkedHashSet<>());
   }
 
-  public static HealthStatusKeywords of(Set<String> keywords) {
-    return new HealthStatusKeywords(keywords);
-  }
-
   private HealthStatusKeywords(Set<String> healthStatusKeywords) {
     this.healthStatusKeywords = new LinkedHashSet<>(healthStatusKeywords);
   }

--- a/back/src/main/java/com/rouby/user/domain/entity/HealthStatusKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/HealthStatusKeywords.java
@@ -3,7 +3,7 @@ package com.rouby.user.domain.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.Getter;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -18,7 +18,7 @@ public class HealthStatusKeywords implements Serializable {
   private Set<String> healthStatusKeywords;
 
   public static HealthStatusKeywords empty(){
-    return new HealthStatusKeywords(new HashSet<>());
+    return new HealthStatusKeywords(new LinkedHashSet<>());
   }
 
   public static HealthStatusKeywords of(Set<String> keywords) {
@@ -26,7 +26,7 @@ public class HealthStatusKeywords implements Serializable {
   }
 
   private HealthStatusKeywords(Set<String> healthStatusKeywords) {
-    this.healthStatusKeywords = new HashSet<>(healthStatusKeywords);
+    this.healthStatusKeywords = new LinkedHashSet<>(healthStatusKeywords);
   }
 
   protected HealthStatusKeywords() {

--- a/back/src/main/java/com/rouby/user/domain/entity/HealthStatusKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/HealthStatusKeywords.java
@@ -1,0 +1,34 @@
+package com.rouby.user.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Getter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@Embeddable
+public class HealthStatusKeywords implements Serializable {
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb")
+  private Set<String> healthStatusKeywords;
+
+  public static HealthStatusKeywords empty(){
+    return new HealthStatusKeywords(new HashSet<>());
+  }
+
+  public static HealthStatusKeywords of(Set<String> keywords) {
+    return new HealthStatusKeywords(keywords);
+  }
+
+  private HealthStatusKeywords(Set<String> healthStatusKeywords) {
+    this.healthStatusKeywords = new HashSet<>(healthStatusKeywords);
+  }
+
+  protected HealthStatusKeywords() {
+  }
+}

--- a/back/src/main/java/com/rouby/user/domain/entity/InterestKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/InterestKeywords.java
@@ -3,8 +3,8 @@ package com.rouby.user.domain.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Getter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -15,18 +15,18 @@ public class InterestKeywords implements Serializable {
 
   @JdbcTypeCode(SqlTypes.JSON)
   @Column(columnDefinition = "jsonb")
-  private List<String> interestKeywords;
+  private Set<String> interestKeywords;
 
   public static InterestKeywords empty(){
-    return new InterestKeywords(new ArrayList<>());
+    return new InterestKeywords(new HashSet<>());
   }
 
-  public static InterestKeywords of(List<String> keywords) {
+  public static InterestKeywords of(Set<String> keywords) {
     return new InterestKeywords(keywords);
   }
 
-  private InterestKeywords(List<String> interestKeywords) {
-    this.interestKeywords = new ArrayList<>(interestKeywords);
+  private InterestKeywords(Set<String> interestKeywords) {
+    this.interestKeywords = new HashSet<>(interestKeywords);
   }
 
   protected InterestKeywords() {

--- a/back/src/main/java/com/rouby/user/domain/entity/InterestKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/InterestKeywords.java
@@ -3,7 +3,7 @@ package com.rouby.user.domain.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import lombok.Getter;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -18,7 +18,7 @@ public class InterestKeywords implements Serializable {
   private Set<String> interestKeywords;
 
   public static InterestKeywords empty(){
-    return new InterestKeywords(new HashSet<>());
+    return new InterestKeywords(new LinkedHashSet<>());
   }
 
   public static InterestKeywords of(Set<String> keywords) {
@@ -26,7 +26,7 @@ public class InterestKeywords implements Serializable {
   }
 
   private InterestKeywords(Set<String> interestKeywords) {
-    this.interestKeywords = new HashSet<>(interestKeywords);
+    this.interestKeywords = new LinkedHashSet<>(interestKeywords);
   }
 
   protected InterestKeywords() {

--- a/back/src/main/java/com/rouby/user/domain/entity/InterestKeywords.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/InterestKeywords.java
@@ -21,10 +21,6 @@ public class InterestKeywords implements Serializable {
     return new InterestKeywords(new LinkedHashSet<>());
   }
 
-  public static InterestKeywords of(Set<String> keywords) {
-    return new InterestKeywords(keywords);
-  }
-
   private InterestKeywords(Set<String> interestKeywords) {
     this.interestKeywords = new LinkedHashSet<>(interestKeywords);
   }

--- a/back/src/main/java/com/rouby/user/domain/entity/User.java
+++ b/back/src/main/java/com/rouby/user/domain/entity/User.java
@@ -42,6 +42,12 @@ public class User extends BaseEntity {
   private DailyActiveTime dailyActiveTime;
 
   @Embedded
+  private CurrentStatusKeywords currentStatusKeywords;
+
+  @Embedded
+  private HealthStatusKeywords healthStatusKeywords;
+
+  @Embedded
   private InterestKeywords interestKeywords;
 
   @Embedded
@@ -112,6 +118,8 @@ public class User extends BaseEntity {
     this.password = password;
     this.nickname = nickname;
     this.dailyActiveTime = DailyActiveTime.defaultTime();
+    this.currentStatusKeywords = CurrentStatusKeywords.empty();
+    this.healthStatusKeywords = HealthStatusKeywords.empty();
     this.interestKeywords = InterestKeywords.empty();
     this.communicationTone = CommunicationTone.empty();
     this.notificationSettings = createDefaultNotificationSettings();

--- a/back/src/test/java/com/rouby/user/presentation/UserControllerTest.java
+++ b/back/src/test/java/com/rouby/user/presentation/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.rouby.user.presentation;
 
 import static com.rouby.notification.email.application.exception.EmailErrorCode.EMAIL_SEND_FAILED;
 import static com.rouby.user.application.exception.UserErrorCode.DUPLICATE_EMAIL;
+import static com.rouby.user.application.exception.UserErrorCode.EMAIL_NOT_VERIFIED;
 import static com.rouby.user.application.exception.UserErrorCode.INVALID_EMAIL_VERIFICATION;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doNothing;
@@ -92,7 +93,7 @@ class UserControllerTest extends ControllerTestSupport {
 
     //given
     CreateUserRequest request = UserRequestStub.toCreateRequest();
-    doThrow(UserException.from(INVALID_EMAIL_VERIFICATION))
+    doThrow(UserException.from(EMAIL_NOT_VERIFIED))
         .when(userFacade).createUser(request.toCommand());
 
     //when and then


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #62 

## 변경 타입
- [x] 신규 기능 추가/수정
- [x] 리팩토링

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] jsonB 타입 HashSet으로 수정
  - [x] 건강상태, 현재상태 추가
  - [x] 테스트 중에 에러코드가 어색한 느낌이라 새로 하나 추가했습니다 `EMAIL_NOT_VERIFIED`
 

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.

## 코멘트
- 현재는 empty() 메서드만 구현해둔 상태입니다 (of는 당장 사용되지 않아서 삭제했습니다)
- 삭제, 수정 개별로 하는 것 보다 그냥 새로운 Set을 만들어서 반환하는게 나을 것 같긴 합니다 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 정보에 현재 상태 키워드와 건강 상태 키워드가 추가되었습니다.
  * 현재 상태 키워드와 건강 상태 키워드를 위한 새로운 데이터 구조가 도입되었습니다.

* **버그 수정**
  * 이메일 인증이 필요할 때 표시되는 오류 메시지가 보다 명확하게 개선되었습니다.

* **리팩터**
  * 관심사 및 소통 톤 데이터가 리스트에서 집합(Set) 구조로 변경되어 중복이 제거되고 순서가 보장되지 않습니다.

* **테스트**
  * 이메일 미인증 사용자 생성 시 발생하는 오류 코드가 최신 상태로 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->