### PR TITLE
[#145][be][notification]feat: 이메일 전송 횟수 제한

### DIFF
--- a/back/src/main/java/com/rouby/notification/email/application/exception/EmailErrorCode.java
+++ b/back/src/main/java/com/rouby/notification/email/application/exception/EmailErrorCode.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum EmailErrorCode implements ErrorCode {
   EMAIL_SEND_FAILED("이메일 전송에 실패했습니다.", "EMAIL_SEND_FAILED", HttpStatus.SERVICE_UNAVAILABLE),
   EMAIL_LOG_SAVE_FAILED("이메일 로그 저장에 실패했습니다.", "EMAIL_LOG_SAVE_FAILED", HttpStatus.INTERNAL_SERVER_ERROR),
+  EMAIL_LIMIT_EXCEEDED("이메일 전송 횟수를 초과했습니다.", "EMAIL_LIMIT_EXCEEDED", HttpStatus.TOO_MANY_REQUESTS),
+
   ;
 
   private final String message;

--- a/back/src/main/java/com/rouby/notification/email/application/service/EmailService.java
+++ b/back/src/main/java/com/rouby/notification/email/application/service/EmailService.java
@@ -8,7 +8,6 @@ import static com.rouby.notification.email.domain.entity.EmailType.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rouby.notification.email.application.dto.SendEmailCommand;
-import com.rouby.notification.email.application.exception.EmailErrorCode;
 import com.rouby.notification.email.application.exception.EmailException;
 import com.rouby.notification.email.application.messaging.EmailSender;
 import com.rouby.notification.email.application.utils.EmailTemplateCreator;

--- a/back/src/main/java/com/rouby/notification/email/domain/entity/EmailAddress.java
+++ b/back/src/main/java/com/rouby/notification/email/domain/entity/EmailAddress.java
@@ -15,11 +15,11 @@ public class EmailAddress implements Serializable {
   @Column(name = "email_address", nullable = false)
   private String emailAddress;
 
-  public static EmailAddress of(String emilAddress) {
-    if (!StringUtils.hasText(emilAddress)) {
+  public static EmailAddress of(String emailAddress) {
+    if (!StringUtils.hasText(emailAddress)) {
       throw new IllegalArgumentException("이메일 주소는 비어 있을 수 없습니다.");
     }
-    return new EmailAddress(emilAddress);
+    return new EmailAddress(emailAddress);
   }
 
   private EmailAddress(String emailAddress) {

--- a/back/src/main/java/com/rouby/notification/email/domain/entity/EmailAddress.java
+++ b/back/src/main/java/com/rouby/notification/email/domain/entity/EmailAddress.java
@@ -13,7 +13,7 @@ import org.springframework.util.StringUtils;
 public class EmailAddress implements Serializable {
 
   @Column(name = "email_address", nullable = false)
-  private String emilAddress;
+  private String emailAddress;
 
   public static EmailAddress of(String emilAddress) {
     if (!StringUtils.hasText(emilAddress)) {
@@ -22,8 +22,8 @@ public class EmailAddress implements Serializable {
     return new EmailAddress(emilAddress);
   }
 
-  private EmailAddress(String emilAddress) {
-    this.emilAddress = emilAddress;
+  private EmailAddress(String emailAddress) {
+    this.emailAddress = emailAddress;
   }
 
   protected EmailAddress() {}

--- a/back/src/main/java/com/rouby/notification/email/domain/repository/EmailLogRepository.java
+++ b/back/src/main/java/com/rouby/notification/email/domain/repository/EmailLogRepository.java
@@ -1,8 +1,11 @@
 package com.rouby.notification.email.domain.repository;
 
 import com.rouby.notification.email.domain.entity.EmailLog;
+import com.rouby.notification.email.domain.entity.EmailType;
 
 public interface EmailLogRepository {
 
   EmailLog save(EmailLog entity);
+
+  long countSentEmailIsToday(String email, EmailType emailType);
 }

--- a/back/src/main/java/com/rouby/notification/email/infrastructure/persistence/jpa/EmailLogJpaRepository.java
+++ b/back/src/main/java/com/rouby/notification/email/infrastructure/persistence/jpa/EmailLogJpaRepository.java
@@ -5,5 +5,5 @@ import com.rouby.notification.email.domain.repository.EmailLogRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmailLogJpaRepository extends
-    JpaRepository<EmailLog, Long>, EmailLogRepository {
+    JpaRepository<EmailLog, Long>, EmailLogRepository, EmailLogJpaRepositoryCustom {
 }

--- a/back/src/main/java/com/rouby/notification/email/infrastructure/persistence/jpa/EmailLogJpaRepositoryCustom.java
+++ b/back/src/main/java/com/rouby/notification/email/infrastructure/persistence/jpa/EmailLogJpaRepositoryCustom.java
@@ -1,5 +1,9 @@
 package com.rouby.notification.email.infrastructure.persistence.jpa;
 
+import com.rouby.notification.email.domain.entity.EmailType;
+
 public interface EmailLogJpaRepositoryCustom {
+
+  long countSentEmailIsToday(String email, EmailType emailType);
 
 }

--- a/back/src/main/java/com/rouby/notification/email/infrastructure/persistence/jpa/EmailLogJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/notification/email/infrastructure/persistence/jpa/EmailLogJpaRepositoryCustomImpl.java
@@ -1,11 +1,38 @@
 package com.rouby.notification.email.infrastructure.persistence.jpa;
 
+import static com.rouby.notification.email.domain.entity.SendStatus.*;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.rouby.notification.email.domain.entity.EmailAddress;
+import com.rouby.notification.email.domain.entity.EmailType;
+import com.rouby.notification.email.domain.entity.QEmailLog;
+import com.rouby.notification.email.domain.entity.SendStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class EmailLogJpaRepositoryCustomImpl {
+public class EmailLogJpaRepositoryCustomImpl implements EmailLogJpaRepositoryCustom {
 
   private final JPAQueryFactory jpaQueryFactory;
 
+  @Override
+  public long countSentEmailIsToday(String email, EmailType emailType) {
+    LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+    LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+    QEmailLog emailLog = QEmailLog.emailLog;
+
+    return jpaQueryFactory
+        .select(emailLog.count())
+        .from(emailLog)
+        .where(
+            emailLog.address.emilAddress.eq(email),
+            emailLog.type.eq(emailType),
+            emailLog.status.eq(SENT),
+            emailLog.createdAt.goe(startOfDay),
+            emailLog.createdAt.lt(endOfDay)
+        )
+        .fetchOne();
+  }
 }

--- a/back/src/main/java/com/rouby/notification/email/infrastructure/persistence/jpa/EmailLogJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/notification/email/infrastructure/persistence/jpa/EmailLogJpaRepositoryCustomImpl.java
@@ -27,7 +27,7 @@ public class EmailLogJpaRepositoryCustomImpl implements EmailLogJpaRepositoryCus
         .select(emailLog.count())
         .from(emailLog)
         .where(
-            emailLog.address.emilAddress.eq(email),
+            emailLog.address.emailAddress.eq(email),
             emailLog.type.eq(emailType),
             emailLog.status.eq(SENT),
             emailLog.createdAt.goe(startOfDay),

--- a/back/src/main/java/com/rouby/user/application/UserFacade.java
+++ b/back/src/main/java/com/rouby/user/application/UserFacade.java
@@ -1,6 +1,8 @@
 package com.rouby.user.application;
 
 
+import static com.rouby.notification.email.domain.entity.EmailType.RESET_PASSWORD;
+import static com.rouby.notification.email.domain.entity.EmailType.VERIFICATION;
 import static com.rouby.user.application.exception.UserErrorCode.DUPLICATE_EMAIL;
 
 import com.rouby.common.props.URIProperty;
@@ -38,6 +40,8 @@ public class UserFacade {
   public void sendEmailVerification(SendEmailVerificationCommand command) {
     String email = command.email();
 
+    emailService.checkSendLimit(email, VERIFICATION);
+
     if (userReadService.alreadyExistsEmail(email)) {
       throw UserException.from(DUPLICATE_EMAIL);
     }
@@ -62,10 +66,9 @@ public class UserFacade {
   }
 
   public void findPassword(FindPasswordCommand command) {
-
     String token = userWriteService.getResetPasswordLink(command);
-
     String resetPasswordLink = uriProperty.generateResetPasswordLink(command.email(), token);
+    emailService.checkSendLimit(command.email(), RESET_PASSWORD);
 
     try {
       emailService.send(command.toSendEmailCommand(command.email(), resetPasswordLink));
@@ -97,6 +100,4 @@ public class UserFacade {
         user.getRole().toString(),
         user.getEmail()));
   }
-
-
 }

--- a/back/src/main/resources/properties/mail.yml
+++ b/back/src/main/resources/properties/mail.yml
@@ -9,3 +9,6 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
     default-encoding: UTF-8
+
+email:
+  send-limit: 2


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #145

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 이메일 전송 횟수 제한 기능 추가

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- 현재는 횟수를 환경 변수로써 관리하고 있습니다.
- 런타임 환경에서 동적으로 횟수를 변경하려면 Config 서버를 두거나, DB를 사용하는 방법이 있을 듯 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이메일 전송 횟수 제한 기능이 추가되었습니다. 사용자는 하루에 정해진 횟수(기본값: 2회) 이상 이메일 인증 또는 비밀번호 재설정 이메일을 받을 수 없습니다.
  * 이메일 전송 횟수 초과 시 안내 메시지가 제공됩니다.

* **설정**
  * 이메일 전송 제한 횟수를 설정할 수 있는 항목이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->