### PR TITLE
[#165][be][common] AesEncryptUtils/ HmacSignUtils 분리

### DIFF
--- a/back/src/main/java/com/rouby/common/utils/AesCryptoUtils.java
+++ b/back/src/main/java/com/rouby/common/utils/AesCryptoUtils.java
@@ -22,7 +22,7 @@ public class AesCryptoUtils {
           "AES 키는 최소 %d 바이트 이상이어야 합니다.", KEY_LENGTH
       ));
     }
-    this.aesKey = Arrays.copyOf(keyBytes, IV_LENGTH);
+    this.aesKey = Arrays.copyOf(keyBytes, KEY_LENGTH);
   }
 
 

--- a/back/src/main/java/com/rouby/common/utils/AesCryptoUtils.java
+++ b/back/src/main/java/com/rouby/common/utils/AesCryptoUtils.java
@@ -1,0 +1,53 @@
+package com.rouby.common.utils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class AesCryptoUtils {
+  private static final int IV_LENGTH = 16;
+  private static final int KEY_LENGTH = 32;
+  private final SecureRandom secureRandom = new SecureRandom();
+  private final byte[] aesKey;
+
+  public AesCryptoUtils (String aesKeyRaw) {
+    byte[] keyBytes = aesKeyRaw.getBytes(UTF_8);
+    if (keyBytes.length < KEY_LENGTH) {
+      throw new IllegalStateException(String.format(
+          "AES 키는 최소 %d 바이트 이상이어야 합니다.", KEY_LENGTH
+      ));
+    }
+    this.aesKey = Arrays.copyOf(keyBytes, IV_LENGTH);
+  }
+
+
+  public byte[] encrypt(String plaintext) throws Exception {
+    byte[] iv = new byte[IV_LENGTH];
+    secureRandom.nextBytes(iv);
+    Cipher cipher = initCipher(Cipher.ENCRYPT_MODE, iv);
+    byte[] ciphertext = cipher.doFinal(plaintext.getBytes(UTF_8));
+    return ByteBuffer.allocate(iv.length + ciphertext.length).put(iv).put(ciphertext).array();
+  }
+
+  public String decrypt(byte[] encrypted) throws Exception {
+    ByteBuffer buffer = ByteBuffer.wrap(encrypted);
+    byte[] iv = new byte[IV_LENGTH];
+    buffer.get(iv);
+    byte[] ciphertext = new byte[buffer.remaining()];
+    buffer.get(ciphertext);
+    Cipher cipher = initCipher(Cipher.DECRYPT_MODE, iv);
+    byte[] plain = cipher.doFinal(ciphertext);
+    return new String(plain, UTF_8);
+  }
+
+  private Cipher initCipher(int mode, byte[] iv) throws Exception {
+    Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+    cipher.init(mode, new SecretKeySpec(aesKey, "AES"), new IvParameterSpec(iv));
+    return cipher;
+  }
+}

--- a/back/src/main/java/com/rouby/common/utils/HmacSignUtils.java
+++ b/back/src/main/java/com/rouby/common/utils/HmacSignUtils.java
@@ -8,12 +8,19 @@ import javax.crypto.spec.SecretKeySpec;
 
 public class HmacSignUtils {
   private final byte[] hmacKey;
+  private static final int MIN_KEY_LENGTH = 32;
 
   public HmacSignUtils(String hmacKeyRaw) {
+    if (hmacKeyRaw == null || hmacKeyRaw.getBytes(UTF_8).length < MIN_KEY_LENGTH) {
+        throw new IllegalArgumentException(String.format(
+            "HMAC 키는 최소 %d 바이트 이상이어야 합니다.", MIN_KEY_LENGTH
+        ));
+    }
     this.hmacKey = hmacKeyRaw.getBytes(UTF_8);
   }
 
   public byte[] sign(byte[] data) throws Exception {
+
     Mac mac = Mac.getInstance("HmacSHA256");
     mac.init(new SecretKeySpec(hmacKey, "HmacSHA256"));
     return mac.doFinal(data);

--- a/back/src/main/java/com/rouby/common/utils/HmacSignUtils.java
+++ b/back/src/main/java/com/rouby/common/utils/HmacSignUtils.java
@@ -1,0 +1,26 @@
+package com.rouby.common.utils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.security.MessageDigest;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+public class HmacSignUtils {
+  private final byte[] hmacKey;
+
+  public HmacSignUtils(String hmacKeyRaw) {
+    this.hmacKey = hmacKeyRaw.getBytes(UTF_8);
+  }
+
+  public byte[] sign(byte[] data) throws Exception {
+    Mac mac = Mac.getInstance("HmacSHA256");
+    mac.init(new SecretKeySpec(hmacKey, "HmacSHA256"));
+    return mac.doFinal(data);
+  }
+
+  public boolean verify(byte[] data, byte[] expectedSignature) throws Exception {
+    byte[] actual = sign(data);
+    return MessageDigest.isEqual(expectedSignature, actual);
+  }
+}

--- a/back/src/main/java/com/rouby/user/infrastructure/token/AesHmacVerificationTokenProvider.java
+++ b/back/src/main/java/com/rouby/user/infrastructure/token/AesHmacVerificationTokenProvider.java
@@ -1,17 +1,9 @@
 package com.rouby.user.infrastructure.token;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
+import com.rouby.common.utils.AesCryptoUtils;
+import com.rouby.common.utils.HmacSignUtils;
 import jakarta.annotation.PostConstruct;
-import java.nio.ByteBuffer;
-import java.security.MessageDigest;
-import java.security.SecureRandom;
-import java.util.Arrays;
 import java.util.Base64;
-import javax.crypto.Cipher;
-import javax.crypto.Mac;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -21,8 +13,6 @@ import org.springframework.stereotype.Component;
 public class AesHmacVerificationTokenProvider {
 
   private static final String TOKEN_PREFIX = "EmailVerification ";
-  private static final int IV_LENGTH = 16;
-  private static final int KEY_LENGTH = 32;
   private static final Base64.Encoder ENCODER = Base64.getEncoder();
   private static final Base64.Decoder DECODER = Base64.getDecoder();
 
@@ -33,20 +23,13 @@ public class AesHmacVerificationTokenProvider {
   @Value("${verification-token.expiration}")
   private long expirationMillis;
 
-  private byte[] aesKey;
-  private byte[] hmacKey;
-  private final SecureRandom secureRandom = new SecureRandom();
+  private AesCryptoUtils cryptoUtils;
+  private HmacSignUtils signUtils;
 
   @PostConstruct
-  private void initKey() {
-    byte[] keyBytes = aesKeyRaw.getBytes(UTF_8);
-    if (keyBytes.length < KEY_LENGTH) {
-      throw new IllegalStateException(String.format(
-          "AES 키는 최소 %d 바이트 이상이어야 합니다.", KEY_LENGTH
-      ));
-    }
-    aesKey = Arrays.copyOf(keyBytes, IV_LENGTH);
-    hmacKey = hmacKeyRaw.getBytes(UTF_8);
+  private void init() {
+    this.cryptoUtils = new AesCryptoUtils(aesKeyRaw);
+    this.signUtils = new HmacSignUtils(hmacKeyRaw);
   }
 
   public String createVerificationToken(String email) {
@@ -55,38 +38,51 @@ public class AesHmacVerificationTokenProvider {
     }
     VerificationPayload payload = new VerificationPayload(email,
         System.currentTimeMillis() + expirationMillis);
-    byte[] encrypted = encrypt(payload.serialize());
-    byte[] signature = sign(encrypted);
-    return TOKEN_PREFIX + encode(encrypted) + "." + encode(signature);
+    try {
+      byte[] encrypted = cryptoUtils.encrypt(payload.serialize());
+      byte[] signature = signUtils.sign(encrypted);
+      return TOKEN_PREFIX + encode(encrypted) + "." + encode(signature);
+    } catch (Exception e) {
+      throw new RuntimeException("토큰 생성 실패", e);
+    }
   }
 
   public boolean validateVerificationToken(String token) {
     TokenParts parts = parse(token);
-    if (parts == null || !verify(parts.encrypted(), parts.signature())) {
+    if (parts == null) {
       return false;
     }
-
-    VerificationPayload payload = deserializeSafely(parts.encrypted());
-    return payload != null && payload.exp() > System.currentTimeMillis();
+    try {
+      if (!signUtils.verify(parts.encrypted(), parts.signature())) {
+        return false;
+      }
+      VerificationPayload payload = deserializeSafely(parts.encrypted());
+      return payload != null && payload.exp() > System.currentTimeMillis();
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   public String extractEmail(String token) {
     TokenParts parts = parse(token);
-    if (parts == null || !verify(parts.encrypted(), parts.signature())) {
-      throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
-    }
+    try {
+      if (parts == null || !signUtils.verify(parts.encrypted(), parts.signature())) {
+        throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+      }
 
-    VerificationPayload payload = deserializeSafely(parts.encrypted());
-    if (payload == null) {
-      throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+      VerificationPayload payload = deserializeSafely(parts.encrypted());
+      if (payload == null) {
+        throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+      }
+      return payload.email();
+    } catch (Exception e) {
+      throw new IllegalArgumentException("유효하지 않은 토큰입니다.", e);
     }
-
-    return payload.email();
   }
 
   private VerificationPayload deserializeSafely(byte[] encrypted) {
     try {
-      String plain = decrypt(encrypted);
+      String plain = cryptoUtils.decrypt(encrypted);
       return VerificationPayload.deserialize(plain);
     } catch (Exception e) {
       log.debug("토큰 역직렬화 실패: {}", e.getMessage());
@@ -94,69 +90,10 @@ public class AesHmacVerificationTokenProvider {
     }
   }
 
-  private byte[] encrypt(String plaintext) {
-    try {
-      byte[] iv = new byte[IV_LENGTH];
-      secureRandom.nextBytes(iv);
-      Cipher cipher = initCipher(Cipher.ENCRYPT_MODE, iv);
-      byte[] ciphertext = cipher.doFinal(plaintext.getBytes(UTF_8));
-      return ByteBuffer.allocate(iv.length + ciphertext.length)
-          .put(iv)
-          .put(ciphertext)
-          .array();
-    } catch (Exception e) {
-      log.error("암호화 실패: {}", e.getMessage());
-      throw new RuntimeException("암호화 실패", e);
-    }
-  }
-
-  private String decrypt(byte[] data) {
-    try {
-      ByteBuffer buffer = ByteBuffer.wrap(data);
-      byte[] iv = new byte[IV_LENGTH];
-      buffer.get(iv);
-      byte[] ciphertext = new byte[buffer.remaining()];
-      buffer.get(ciphertext);
-      Cipher cipher = initCipher(Cipher.DECRYPT_MODE, iv);
-      byte[] plaintext = cipher.doFinal(ciphertext);
-      return new String(plaintext, UTF_8);
-    } catch (Exception e) {
-      log.error("복호화 실패: {}", e.getMessage());
-      throw new RuntimeException("복호화 실패", e);
-    }
-  }
-
-  private Cipher initCipher(int mode, byte[] iv) {
-    try {
-      Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-      cipher.init(mode,
-          new SecretKeySpec(aesKey, "AES"),
-          new IvParameterSpec(iv));
-      return cipher;
-    } catch (Exception e) {
-      log.error("Cipher 초기화 실패: {}", e.getMessage());
-      throw new RuntimeException("Cipher 초기화 실패", e);
-    }
-  }
-
-  private byte[] sign(byte[] data) {
-    try {
-      Mac mac = Mac.getInstance("HmacSHA256");
-      mac.init(new SecretKeySpec(hmacKey, "HmacSHA256"));
-      return mac.doFinal(data);
-    } catch (Exception e) {
-      log.error("서명 생성 실패: {}", e.getMessage());
-      throw new RuntimeException("서명 생성 실패", e);
-    }
-  }
-
-  private boolean verify(byte[] data, byte[] expectedSignature) {
-    byte[] actual = sign(data);
-    return MessageDigest.isEqual(expectedSignature, actual);
-  }
-
   private TokenParts parse(String token) {
-    if (token == null || !token.startsWith(TOKEN_PREFIX)) return null;
+    if (token == null || !token.startsWith(TOKEN_PREFIX)) {
+      return null;
+    }
     String rawToken = token.substring(TOKEN_PREFIX.length());
 
     String[] parts = rawToken.split("\\.", 2);
@@ -179,9 +116,11 @@ public class AesHmacVerificationTokenProvider {
   }
 
   private record VerificationPayload(String email, long exp) {
+
     String serialize() {
       return email + ":" + exp;
     }
+
     static VerificationPayload deserialize(String input) {
       int lastColonIndex = input.lastIndexOf(':');
       if (lastColonIndex == -1) {
@@ -199,5 +138,7 @@ public class AesHmacVerificationTokenProvider {
     }
   }
 
-  private record TokenParts(byte[] encrypted, byte[] signature) {}
+  private record TokenParts(byte[] encrypted, byte[] signature) {
+
+  }
 }

--- a/back/src/test/java/com/rouby/user/infrastructure/token/AesHmacVerificationTokenProviderTest.java
+++ b/back/src/test/java/com/rouby/user/infrastructure/token/AesHmacVerificationTokenProviderTest.java
@@ -27,7 +27,7 @@ class AesHmacVerificationTokenProviderTest {
     ReflectionTestUtils.setField(tokenProvider, "hmacKeyRaw", VALID_HMAC_KEY);
     ReflectionTestUtils.setField(tokenProvider, "expirationMillis", DEFAULT_EXPIRATION);
 
-    ReflectionTestUtils.invokeMethod(tokenProvider, "initKey");
+    ReflectionTestUtils.invokeMethod(tokenProvider, "init");
   }
 
   @Nested
@@ -36,19 +36,19 @@ class AesHmacVerificationTokenProviderTest {
 
     @Test
     @DisplayName("정상적인 AES 키로 초기화 성공")
-    void initKey_WithValidKey_Success() {
+    void init_WithValidKey_Success() {
       // given
       AesHmacVerificationTokenProvider provider = new AesHmacVerificationTokenProvider();
       ReflectionTestUtils.setField(provider, "aesKeyRaw", VALID_AES_KEY);
       ReflectionTestUtils.setField(provider, "hmacKeyRaw", VALID_HMAC_KEY);
 
       // when & then
-      assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(provider, "initKey"));
+      assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(provider, "init"));
     }
 
     @Test
     @DisplayName("짧은 AES 키로 초기화 실패")
-    void initKey_WithShortKey_ThrowsException() {
+    void init_WithShortKey_ThrowsException() {
       // given
       AesHmacVerificationTokenProvider provider = new AesHmacVerificationTokenProvider();
       ReflectionTestUtils.setField(provider, "aesKeyRaw", "short");
@@ -56,322 +56,307 @@ class AesHmacVerificationTokenProviderTest {
       // when & then
       IllegalStateException exception = assertThrows(
           IllegalStateException.class,
-          () -> ReflectionTestUtils.invokeMethod(provider, "initKey")
+          () -> ReflectionTestUtils.invokeMethod(provider, "init")
       );
       assertThat(exception.getMessage()).isEqualTo("AES 키는 최소 32 바이트 이상이어야 합니다.");
     }
-
-    @Test
-    @DisplayName("긴 AES 키는 32바이트로 자동 잘림")
-    void initKey_WithLongKey_TruncatedTo16Bytes() {
-      // given
-      AesHmacVerificationTokenProvider provider = new AesHmacVerificationTokenProvider();
-      String longKey = "this-is-a-very-long-key-more-than-32-bytes";
-      ReflectionTestUtils.setField(provider, "aesKeyRaw", longKey);
-      ReflectionTestUtils.setField(provider, "hmacKeyRaw", longKey);
-
-      // when
-      ReflectionTestUtils.invokeMethod(provider, "initKey");
-      // then
-      byte[] aesKey = (byte[]) ReflectionTestUtils.getField(provider, "aesKey");
-      assertThat(aesKey).hasSize(16);
-    }
   }
 
-  @Nested
-  @DisplayName("토큰 생성 테스트")
-  class TokenCreationTest {
+    @Nested
+    @DisplayName("토큰 생성 테스트")
+    class TokenCreationTest {
 
-    @Test
-    @DisplayName("유효한 이메일로 토큰 생성 성공")
-    void createVerificationToken_WithValidEmail_Success() {
-      // given
-      String email = "test@example.com";
+      @Test
+      @DisplayName("유효한 이메일로 토큰 생성 성공")
+      void createVerificationToken_WithValidEmail_Success() {
+        // given
+        String email = "test@example.com";
 
-      // when
-      String token = tokenProvider.createVerificationToken(email);
+        // when
+        String token = tokenProvider.createVerificationToken(email);
 
-      // then
-      assertThat(token).isNotNull();
-      assertThat(token).contains(".");
+        // then
+        assertThat(token).isNotNull();
+        assertThat(token).contains(".");
 
-      // 토큰 형식 검증
-      String[] parts = token.substring("EmailVerification ".length()).split("\\.");
-      assertThat(parts).hasSize(2);
-      assertDoesNotThrow(() -> Base64.getDecoder().decode(parts[0]));
-      assertDoesNotThrow(() -> Base64.getDecoder().decode(parts[1]));
-    }
-
-    @Test
-    @DisplayName("특수문자가 포함된 이메일로 토큰 생성")
-    void createVerificationToken_WithSpecialCharacters_Success() {
-      // given
-      String email = "test+special@example-domain.co.kr";
-
-      // when
-      String token = tokenProvider.createVerificationToken(email);
-
-      // then
-      assertThat(token).isNotNull();
-      assertThat(tokenProvider.extractEmail(token)).isEqualTo(email);
-    }
-
-    @Test
-    @DisplayName("빈 이메일로 토큰 생성")
-    void createVerificationToken_WithEmptyEmail_Success() {
-      // given
-      String email = "";
-
-      // when
-      String token = tokenProvider.createVerificationToken(email);
-
-      // then
-      assertThat(token).isNotNull();
-      assertThat(tokenProvider.extractEmail(token)).isEqualTo(email);
-    }
-  }
-
-  @Nested
-  @DisplayName("토큰 검증 테스트")
-  class TokenValidationTest {
-
-    @Test
-    @DisplayName("유효한 토큰 검증 성공")
-    void validateVerificationToken_WithValidToken_ReturnsTrue() {
-      // given
-      String email = "test@example.com";
-      String token = tokenProvider.createVerificationToken(email);
-
-      // when
-      boolean isValid = tokenProvider.validateVerificationToken(token);
-
-      // then
-      assertThat(isValid).isTrue();
-    }
-
-    @Test
-    @DisplayName("만료된 토큰 검증 실패")
-    void validateVerificationToken_WithExpiredToken_ReturnsFalse() {
-      // given
-      AesHmacVerificationTokenProvider shortExpirationProvider = new AesHmacVerificationTokenProvider();
-      ReflectionTestUtils.setField(shortExpirationProvider, "aesKeyRaw", VALID_AES_KEY);
-      ReflectionTestUtils.setField(shortExpirationProvider, "hmacKeyRaw", VALID_HMAC_KEY);
-      ReflectionTestUtils.setField(shortExpirationProvider, "expirationMillis", 1L);
-      ReflectionTestUtils.invokeMethod(shortExpirationProvider, "initKey");
-
-      String email = "test@example.com";
-      String token = shortExpirationProvider.createVerificationToken(email);
-
-      // when - 만료 대기
-      try {
-        Thread.sleep(10);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
+        // 토큰 형식 검증
+        String[] parts = token.substring("EmailVerification ".length()).split("\\.");
+        assertThat(parts).hasSize(2);
+        assertDoesNotThrow(() -> Base64.getDecoder().decode(parts[0]));
+        assertDoesNotThrow(() -> Base64.getDecoder().decode(parts[1]));
       }
 
-      boolean isValid = shortExpirationProvider.validateVerificationToken(token);
+      @Test
+      @DisplayName("특수문자가 포함된 이메일로 토큰 생성")
+      void createVerificationToken_WithSpecialCharacters_Success() {
+        // given
+        String email = "test+special@example-domain.co.kr";
 
-      // then
-      assertThat(isValid).isFalse();
+        // when
+        String token = tokenProvider.createVerificationToken(email);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(tokenProvider.extractEmail(token)).isEqualTo(email);
+      }
+
+      @Test
+      @DisplayName("빈 이메일로 토큰 생성")
+      void createVerificationToken_WithEmptyEmail_Success() {
+        // given
+        String email = "";
+
+        // when
+        String token = tokenProvider.createVerificationToken(email);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(tokenProvider.extractEmail(token)).isEqualTo(email);
+      }
     }
 
-    @Test
-    @DisplayName("잘못된 형식의 토큰 검증 실패")
-    void validateVerificationToken_WithInvalidFormat_ReturnsFalse() {
-      // given
-      String invalidToken = "invalid.token.format";
+    @Nested
+    @DisplayName("토큰 검증 테스트")
+    class TokenValidationTest {
 
-      // when
-      boolean isValid = tokenProvider.validateVerificationToken(invalidToken);
+      @Test
+      @DisplayName("유효한 토큰 검증 성공")
+      void validateVerificationToken_WithValidToken_ReturnsTrue() {
+        // given
+        String email = "test@example.com";
+        String token = tokenProvider.createVerificationToken(email);
 
-      // then
-      assertThat(isValid).isFalse();
+        // when
+        boolean isValid = tokenProvider.validateVerificationToken(token);
+
+        // then
+        assertThat(isValid).isTrue();
+      }
+
+      @Test
+      @DisplayName("만료된 토큰 검증 실패")
+      void validateVerificationToken_WithExpiredToken_ReturnsFalse() {
+        // given
+        AesHmacVerificationTokenProvider shortExpirationProvider = new AesHmacVerificationTokenProvider();
+        ReflectionTestUtils.setField(shortExpirationProvider, "aesKeyRaw", VALID_AES_KEY);
+        ReflectionTestUtils.setField(shortExpirationProvider, "hmacKeyRaw", VALID_HMAC_KEY);
+        ReflectionTestUtils.setField(shortExpirationProvider, "expirationMillis", 1L);
+        ReflectionTestUtils.invokeMethod(shortExpirationProvider, "init");
+
+        String email = "test@example.com";
+        String token = shortExpirationProvider.createVerificationToken(email);
+
+        // when - 만료 대기
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+
+        boolean isValid = shortExpirationProvider.validateVerificationToken(token);
+
+        // then
+        assertThat(isValid).isFalse();
+      }
+
+      @Test
+      @DisplayName("잘못된 형식의 토큰 검증 실패")
+      void validateVerificationToken_WithInvalidFormat_ReturnsFalse() {
+        // given
+        String invalidToken = "invalid.token.format";
+
+        // when
+        boolean isValid = tokenProvider.validateVerificationToken(invalidToken);
+
+        // then
+        assertThat(isValid).isFalse();
+      }
+
+      @Test
+      @DisplayName("점이 없는 토큰 검증 실패")
+      void validateVerificationToken_WithoutDot_ReturnsFalse() {
+        // given
+        String tokenWithoutDot = "invalidtokenformat";
+
+        // when
+        boolean isValid = tokenProvider.validateVerificationToken(tokenWithoutDot);
+
+        // then
+        assertThat(isValid).isFalse();
+      }
+
+      @Test
+      @DisplayName("Base64 디코딩 실패하는 토큰 검증 실패")
+      void validateVerificationToken_WithInvalidBase64_ReturnsFalse() {
+        // given
+        String invalidBase64Token = "invalid@base64.invalid@base64";
+
+        // when
+        boolean isValid = tokenProvider.validateVerificationToken(invalidBase64Token);
+
+        // then
+        assertThat(isValid).isFalse();
+      }
+
+      @Test
+      @DisplayName("서명이 변조된 토큰 검증 실패")
+      void validateVerificationToken_WithTamperedSignature_ReturnsFalse() {
+        // given
+        String email = "test@example.com";
+        String originalToken = tokenProvider.createVerificationToken(email);
+        String[] parts = originalToken.split("\\.");
+
+        // 서명 부분을 변조
+        String tamperedSignature = Base64.getEncoder().encodeToString("tampered".getBytes());
+        String tamperedToken = parts[0] + "." + tamperedSignature;
+
+        // when
+        boolean isValid = tokenProvider.validateVerificationToken(tamperedToken);
+
+        // then
+        assertThat(isValid).isFalse();
+      }
     }
 
-    @Test
-    @DisplayName("점이 없는 토큰 검증 실패")
-    void validateVerificationToken_WithoutDot_ReturnsFalse() {
-      // given
-      String tokenWithoutDot = "invalidtokenformat";
+    @Nested
+    @DisplayName("이메일 추출 테스트")
+    class EmailExtractionTest {
 
-      // when
-      boolean isValid = tokenProvider.validateVerificationToken(tokenWithoutDot);
+      @Test
+      @DisplayName("유효한 토큰에서 이메일 추출 성공")
+      void extractEmail_WithValidToken_ReturnsEmail() {
+        // given
+        String expectedEmail = "test@example.com";
+        String token = tokenProvider.createVerificationToken(expectedEmail);
 
-      // then
-      assertThat(isValid).isFalse();
+        // when
+        String extractedEmail = tokenProvider.extractEmail(token);
+
+        // then
+        assertThat(extractedEmail).isEqualTo(expectedEmail);
+      }
+
+      @Test
+      @DisplayName("유효하지 않은 토큰에서 이메일 추출 시 예외 발생")
+      void extractEmail_WithInvalidToken_ThrowsException() {
+        // given
+        String invalidToken = "invalid.token";
+
+        // when & then
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> tokenProvider.extractEmail(invalidToken)
+        );
+        assertThat(exception.getMessage()).contains("유효하지 않은 토큰입니다");
+      }
+
+      @Test
+      @DisplayName("서명이 변조된 토큰에서 이메일 추출 시 예외 발생")
+      void extractEmail_WithTamperedToken_ThrowsException() {
+        // given
+        String email = "test@example.com";
+        String originalToken = tokenProvider.createVerificationToken(email);
+        String[] parts = originalToken.split("\\.");
+
+        // 암호화된 부분을 변조
+        String tamperedEncrypted = Base64.getEncoder().encodeToString("tampered".getBytes());
+        String tamperedToken = tamperedEncrypted + "." + parts[1];
+
+        // when & then
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> tokenProvider.extractEmail(tamperedToken)
+        );
+        assertThat(exception.getMessage()).contains("유효하지 않은 토큰입니다");
+      }
     }
 
-    @Test
-    @DisplayName("Base64 디코딩 실패하는 토큰 검증 실패")
-    void validateVerificationToken_WithInvalidBase64_ReturnsFalse() {
-      // given
-      String invalidBase64Token = "invalid@base64.invalid@base64";
+    @Nested
+    @DisplayName("암호화/복호화 테스트")
+    class EncryptionTest {
 
-      // when
-      boolean isValid = tokenProvider.validateVerificationToken(invalidBase64Token);
+      @Test
+      @DisplayName("동일한 이메일로 생성한 토큰들은 서로 다름 (시간 차이)")
+      void createVerificationToken_SameEmail_DifferentTokens() throws InterruptedException {
+        // given
+        String email = "test@example.com";
 
-      // then
-      assertThat(isValid).isFalse();
+        // when
+        String token1 = tokenProvider.createVerificationToken(email);
+        Thread.sleep(1);
+        String token2 = tokenProvider.createVerificationToken(email);
+
+        // then
+        assertThat(token1).isNotEqualTo(token2);
+        assertThat(tokenProvider.extractEmail(token1)).isEqualTo(email);
+        assertThat(tokenProvider.extractEmail(token2)).isEqualTo(email);
+      }
     }
 
-    @Test
-    @DisplayName("서명이 변조된 토큰 검증 실패")
-    void validateVerificationToken_WithTamperedSignature_ReturnsFalse() {
-      // given
-      String email = "test@example.com";
-      String originalToken = tokenProvider.createVerificationToken(email);
-      String[] parts = originalToken.split("\\.");
+    @Nested
+    @DisplayName("보안 테스트")
+    class SecurityTest {
 
-      // 서명 부분을 변조
-      String tamperedSignature = Base64.getEncoder().encodeToString("tampered".getBytes());
-      String tamperedToken = parts[0] + "." + tamperedSignature;
+      @Test
+      @DisplayName("다른 HMAC 키로 생성된 토큰은 검증 실패")
+      void validateToken_WithDifferentHmacKey_ReturnsFalse() {
+        // given - 다른 HMAC 키를 가진 provider
+        AesHmacVerificationTokenProvider otherProvider = new AesHmacVerificationTokenProvider();
+        ReflectionTestUtils.setField(otherProvider, "aesKeyRaw", VALID_AES_KEY);
+        ReflectionTestUtils.setField(otherProvider, "hmacKeyRaw", "different-hmac-key");
+        ReflectionTestUtils.setField(otherProvider, "expirationMillis", DEFAULT_EXPIRATION);
+        ReflectionTestUtils.invokeMethod(otherProvider, "init");
 
-      // when
-      boolean isValid = tokenProvider.validateVerificationToken(tamperedToken);
+        String email = "test@example.com";
+        String token = otherProvider.createVerificationToken(email);
 
-      // then
-      assertThat(isValid).isFalse();
+        // when
+        boolean isValid = tokenProvider.validateVerificationToken(token);
+
+        // then
+        assertThat(isValid).isFalse();
+      }
+
+      @Test
+      @DisplayName("다른 AES 키로 생성된 토큰은 검증 실패")
+      void validateToken_WithDifferentAesKey_ReturnsFalse() {
+        // given
+        AesHmacVerificationTokenProvider otherProvider = new AesHmacVerificationTokenProvider();
+        ReflectionTestUtils.setField(otherProvider, "aesKeyRaw",
+            "different-aes-key-123-long-long-key");
+        ReflectionTestUtils.setField(otherProvider, "hmacKeyRaw", VALID_HMAC_KEY);
+        ReflectionTestUtils.setField(otherProvider, "expirationMillis", DEFAULT_EXPIRATION);
+        ReflectionTestUtils.invokeMethod(otherProvider, "init");
+
+        String email = "test@example.com";
+        String token = otherProvider.createVerificationToken(email);
+
+        // when
+        boolean isValid = tokenProvider.validateVerificationToken(token);
+
+        // then
+        assertThat(isValid).isFalse();
+      }
+    }
+
+    @Nested
+    @DisplayName("통합 테스트")
+    class IntegrationTest {
+
+      @Test
+      @DisplayName("토큰 생성 -> 검증 -> 이메일 추출 전체 플로우")
+      void fullTokenWorkflow_Success() {
+        // given
+        String email = "integration.test@example.com";
+
+        // when
+        String token = tokenProvider.createVerificationToken(email);
+        boolean isValid = tokenProvider.validateVerificationToken(token);
+        String extractedEmail = tokenProvider.extractEmail(token);
+
+        // then
+        assertThat(isValid).isTrue();
+        assertThat(extractedEmail).isEqualTo(email);
+      }
     }
   }
-
-  @Nested
-  @DisplayName("이메일 추출 테스트")
-  class EmailExtractionTest {
-
-    @Test
-    @DisplayName("유효한 토큰에서 이메일 추출 성공")
-    void extractEmail_WithValidToken_ReturnsEmail() {
-      // given
-      String expectedEmail = "test@example.com";
-      String token = tokenProvider.createVerificationToken(expectedEmail);
-
-      // when
-      String extractedEmail = tokenProvider.extractEmail(token);
-
-      // then
-      assertThat(extractedEmail).isEqualTo(expectedEmail);
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 토큰에서 이메일 추출 시 예외 발생")
-    void extractEmail_WithInvalidToken_ThrowsException() {
-      // given
-      String invalidToken = "invalid.token";
-
-      // when & then
-      IllegalArgumentException exception = assertThrows(
-          IllegalArgumentException.class,
-          () -> tokenProvider.extractEmail(invalidToken)
-      );
-      assertThat(exception.getMessage()).contains("유효하지 않은 토큰입니다");
-    }
-
-    @Test
-    @DisplayName("서명이 변조된 토큰에서 이메일 추출 시 예외 발생")
-    void extractEmail_WithTamperedToken_ThrowsException() {
-      // given
-      String email = "test@example.com";
-      String originalToken = tokenProvider.createVerificationToken(email);
-      String[] parts = originalToken.split("\\.");
-
-      // 암호화된 부분을 변조
-      String tamperedEncrypted = Base64.getEncoder().encodeToString("tampered".getBytes());
-      String tamperedToken = tamperedEncrypted + "." + parts[1];
-
-      // when & then
-      IllegalArgumentException exception = assertThrows(
-          IllegalArgumentException.class,
-          () -> tokenProvider.extractEmail(tamperedToken)
-      );
-      assertThat(exception.getMessage()).contains("유효하지 않은 토큰입니다");
-    }
-  }
-
-  @Nested
-  @DisplayName("암호화/복호화 테스트")
-  class EncryptionTest {
-
-    @Test
-    @DisplayName("동일한 이메일로 생성한 토큰들은 서로 다름 (시간 차이)")
-    void createVerificationToken_SameEmail_DifferentTokens() throws InterruptedException {
-      // given
-      String email = "test@example.com";
-
-      // when
-      String token1 = tokenProvider.createVerificationToken(email);
-      Thread.sleep(1);
-      String token2 = tokenProvider.createVerificationToken(email);
-
-      // then
-      assertThat(token1).isNotEqualTo(token2);
-      assertThat(tokenProvider.extractEmail(token1)).isEqualTo(email);
-      assertThat(tokenProvider.extractEmail(token2)).isEqualTo(email);
-    }
-  }
-
-  @Nested
-  @DisplayName("보안 테스트")
-  class SecurityTest {
-
-    @Test
-    @DisplayName("다른 HMAC 키로 생성된 토큰은 검증 실패")
-    void validateToken_WithDifferentHmacKey_ReturnsFalse() {
-      // given - 다른 HMAC 키를 가진 provider
-      AesHmacVerificationTokenProvider otherProvider = new AesHmacVerificationTokenProvider();
-      ReflectionTestUtils.setField(otherProvider, "aesKeyRaw", VALID_AES_KEY);
-      ReflectionTestUtils.setField(otherProvider, "hmacKeyRaw", "different-hmac-key");
-      ReflectionTestUtils.setField(otherProvider, "expirationMillis", DEFAULT_EXPIRATION);
-      ReflectionTestUtils.invokeMethod(otherProvider, "initKey");
-
-      String email = "test@example.com";
-      String token = otherProvider.createVerificationToken(email);
-
-      // when
-      boolean isValid = tokenProvider.validateVerificationToken(token);
-
-      // then
-      assertThat(isValid).isFalse();
-    }
-
-    @Test
-    @DisplayName("다른 AES 키로 생성된 토큰은 검증 실패")
-    void validateToken_WithDifferentAesKey_ReturnsFalse() {
-      // given
-      AesHmacVerificationTokenProvider otherProvider = new AesHmacVerificationTokenProvider();
-      ReflectionTestUtils.setField(otherProvider, "aesKeyRaw", "different-aes-key-123-long-long-key");
-      ReflectionTestUtils.setField(otherProvider, "hmacKeyRaw", VALID_HMAC_KEY);
-      ReflectionTestUtils.setField(otherProvider, "expirationMillis", DEFAULT_EXPIRATION);
-      ReflectionTestUtils.invokeMethod(otherProvider, "initKey");
-
-      String email = "test@example.com";
-      String token = otherProvider.createVerificationToken(email);
-
-      // when
-      boolean isValid = tokenProvider.validateVerificationToken(token);
-
-      // then
-      assertThat(isValid).isFalse();
-    }
-  }
-
-  @Nested
-  @DisplayName("통합 테스트")
-  class IntegrationTest {
-
-    @Test
-    @DisplayName("토큰 생성 -> 검증 -> 이메일 추출 전체 플로우")
-    void fullTokenWorkflow_Success() {
-      // given
-      String email = "integration.test@example.com";
-
-      // when
-      String token = tokenProvider.createVerificationToken(email);
-      boolean isValid = tokenProvider.validateVerificationToken(token);
-      String extractedEmail = tokenProvider.extractEmail(token);
-
-      // then
-      assertThat(isValid).isTrue();
-      assertThat(extractedEmail).isEqualTo(email);
-    }
-  }
-}

--- a/back/src/test/java/com/rouby/user/infrastructure/token/AesHmacVerificationTokenProviderTest.java
+++ b/back/src/test/java/com/rouby/user/infrastructure/token/AesHmacVerificationTokenProviderTest.java
@@ -16,7 +16,7 @@ class AesHmacVerificationTokenProviderTest {
   private AesHmacVerificationTokenProvider tokenProvider;
 
   private static final String VALID_AES_KEY = "abcdefghijklmnopqrstuvwxyzABCDEF";
-  private static final String VALID_HMAC_KEY = "test-hmac-key-for-signing";
+  private static final String VALID_HMAC_KEY = "abcdefghijklmnopqrstuvwxyzABCDEF";
   private static final long DEFAULT_EXPIRATION = 300000L;
 
   @BeforeEach
@@ -303,7 +303,7 @@ class AesHmacVerificationTokenProviderTest {
         // given - 다른 HMAC 키를 가진 provider
         AesHmacVerificationTokenProvider otherProvider = new AesHmacVerificationTokenProvider();
         ReflectionTestUtils.setField(otherProvider, "aesKeyRaw", VALID_AES_KEY);
-        ReflectionTestUtils.setField(otherProvider, "hmacKeyRaw", "different-hmac-key");
+        ReflectionTestUtils.setField(otherProvider, "hmacKeyRaw", VALID_HMAC_KEY + "different");
         ReflectionTestUtils.setField(otherProvider, "expirationMillis", DEFAULT_EXPIRATION);
         ReflectionTestUtils.invokeMethod(otherProvider, "init");
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #165 

## 변경 타입
- [x] 리팩토링

## 체크리스트
- [x] 관련 테스트를 추가했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * AES 암호화/복호화 및 HMAC-SHA256 서명/검증을 위한 유틸리티 기능이 추가되었습니다.

* **리팩터링**
  * 인증 토큰 처리에서 직접 암호화/서명 구현을 제거하고, 신규 유틸리티 클래스를 사용하도록 구조가 단순화되었습니다.

* **테스트**
  * 초기화 관련 테스트 메서드 명칭이 변경되었으며, 일부 테스트 케이스가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->