### PR TITLE
[#173][be][notification]refactor: 이메일 타입 별 전송 수 조회 쿼리에 index 추가

### DIFF
--- a/back/src/main/java/com/rouby/notification/email/domain/entity/EmailLog.java
+++ b/back/src/main/java/com/rouby/notification/email/domain/entity/EmailLog.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,7 +18,12 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "email_log")
+@Table(
+    name = "email_log",
+    indexes = {
+        @Index(name = "idx_email_created_at", columnList = "email_address, created_at")
+    }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmailLog extends LogBaseEntity {
 

--- a/back/src/test/java/com/rouby/test/data/EmailLogInitRunner.java
+++ b/back/src/test/java/com/rouby/test/data/EmailLogInitRunner.java
@@ -1,0 +1,53 @@
+package com.rouby.test.data;
+
+import com.rouby.notification.email.domain.entity.EmailAddress;
+import com.rouby.notification.email.domain.entity.EmailContent;
+import com.rouby.notification.email.domain.entity.EmailLog;
+import com.rouby.notification.email.domain.entity.EmailType;
+import com.rouby.notification.email.domain.entity.SendStatus;
+import com.rouby.notification.email.infrastructure.persistence.jpa.EmailLogJpaRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+//@Disabled
+public class EmailLogInitRunner {
+
+  @Autowired EmailLogJpaRepository emailLogRepository;
+
+  @Test
+  public void run() {
+    List<EmailLog> logs = new ArrayList<>();
+    for (int i = 0; i < 100_000; i++) {
+      EmailContent content = EmailContent.of("content");
+      EmailAddress address = EmailAddress.of("user" + (i % 1000) + "@example.com");
+
+      EmailType type = EmailType.values()[i % EmailType.values().length];
+      SendStatus status = (i % 10 == 0) ? SendStatus.FAILED : SendStatus.SENT;
+
+      EmailLog log = EmailLog.builder()
+          .content(content)
+          .address(address)
+          .status(status)
+          .type(type)
+          .build();
+
+      logs.add(log);
+
+      if (logs.size() == 1000) {
+        emailLogRepository.saveAll(logs);
+        logs.clear();
+      }
+    }
+
+    if (!logs.isEmpty()) {
+      emailLogRepository.saveAll(logs);
+    }
+
+    System.out.println("✅ 10만 건 삽입 완료");
+  }
+}

--- a/back/src/test/java/com/rouby/test/data/EmailLogInitRunner.java
+++ b/back/src/test/java/com/rouby/test/data/EmailLogInitRunner.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-//@Disabled
+@Disabled
 public class EmailLogInitRunner {
 
   @Autowired EmailLogJpaRepository emailLogRepository;


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #173 

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - x] 이메일 타입 별 전송 수 조회 쿼리에 index를 추가

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
인덱스를 추가하고 나서도 API가 정상 동작하는 지 확인하였습니다.

비교군은 아래와 같습니다.
- index를 추가하지 않았을 때
- 쿼리의 where 절에 포함된 컬럼 모두를 복합 인덱스로 설정하였을 때(`email_address, type, status, created_at`)
- email_address와 createdAt만 복합 인덱스로 설정하였을 때(`email_address, created_at`)

### 비교 방법
비교를 위해 `email_log` 테이블에 10만개의 데이터를 넣고 시작했습니다.

아래의 쿼리를 실행합니다.
```sql
SELECT COUNT(*)
FROM email_log
WHERE email_address = 'test@example.com'
  AND type = 'VERIFICATION'
  AND status = 'SENT'
  AND created_at BETWEEN '2025-07-18 00:00:00' AND '2025-07-19 00:00:00';
```
해당 쿼리를 한 번 씩만 실행하는 것보다, 비교군마다 쿼리를 30번 실행한 값을 비교했습니다.

아래는 결과입니다.

1. index를 추가하지 않았을 때
<img width="312" height="43" alt="인덱스반영전" src="https://github.com/user-attachments/assets/44ce39bf-8204-445f-a26e-bd657718d6bd" />

**= 192 ms**

2. where 절에 포함된 컬럼 모두를 복합 인덱스로 설정하였을 때(`email_address, type, status, created_at`)
<img width="312" height="43" alt="where절모두포함" src="https://github.com/user-attachments/assets/4dc9cb4d-3dc9-4d89-bd18-343d179554bb" />

**= 7 ms**

3. email_address와 createdAt만 복합 인덱스로 설정하였을 때(`email_address, created_at`)
<img width="312" height="43" alt="원래계획" src="https://github.com/user-attachments/assets/d96b14a4-7448-42a1-ad64-2bc2cca153c4" />

**= 6 ms**

보시는 바와 같이 2번과 3번 비교군은 큰 차이가 없습니다. 예상하는 추측으로는 2번과 3번의 차이는 `type, status` 컬럼이 더 있다는 점인데, 두 enum 모두 종류가 현재는 2개이고 많아져봤자 5개 전후이기 때문에 큰 차이가 없는 것으로 생각됩니다.

성능이 큰 차이가 없다면, 굳이 인덱스 크기를 늘릴 필요가 없다고 판단하였습니다.
따라서 원래 계획인, `email_address, created_at` 만을 복합 인덱스로 설정하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **성능 개선**
  * 이메일 로그에서 이메일 주소와 생성일 기준으로의 조회 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->