### PR TITLE
[#92][be][schedule]일정 기간별 조회 api 관련 수정

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.testcontainers:testcontainers:1.21.3' // TC 의존성
     testImplementation 'org.testcontainers:junit-jupiter:1.21.3'  // TC 의존성
     testImplementation 'org.testcontainers:postgresql:1.21.3'     // PostgreSQL 컨테이너 사용

--- a/back/src/main/java/com/rouby/common/dto/ErrorResponse.java
+++ b/back/src/main/java/com/rouby/common/dto/ErrorResponse.java
@@ -3,6 +3,7 @@ package com.rouby.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.rouby.common.exception.CustomException;
+import com.rouby.common.exception.type.ApiErrorCode;
 import java.util.List;
 
 public record ErrorResponse(
@@ -21,6 +22,10 @@ public record ErrorResponse(
 
   public static ErrorResponse from(CustomException ex) {
     return new ErrorResponse(ex.getMessage(), ex.getCode(), null);
+  }
+
+  public static ErrorResponse from(ApiErrorCode apiErrorCode) {
+    return new ErrorResponse(apiErrorCode.getMessage(), apiErrorCode.getCode(), null);
   }
 
   public static ErrorResponse of(String message, String code) {

--- a/back/src/main/java/com/rouby/common/exception/CustomException.java
+++ b/back/src/main/java/com/rouby/common/exception/CustomException.java
@@ -1,6 +1,7 @@
 package com.rouby.common.exception;
 
 import com.rouby.common.exception.type.ErrorCode;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -10,8 +11,15 @@ public class CustomException extends RuntimeException {
   private final HttpStatus status;
   private final String code;
 
-  public CustomException(ErrorCode errorCode) {
+  protected CustomException(ErrorCode errorCode) {
     super(errorCode.getMessage());
+    this.status = errorCode.getStatus();
+    this.code = errorCode.getCode();
+  }
+
+  protected CustomException(ErrorCode errorCode, @NotNull String message) {
+    super(message);
+
     this.status = errorCode.getStatus();
     this.code = errorCode.getCode();
   }

--- a/back/src/main/java/com/rouby/common/exception/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/rouby/common/exception/GlobalExceptionHandler.java
@@ -43,8 +43,7 @@ public class GlobalExceptionHandler {
 
     return ResponseEntity
         .status(UNAUTHORIZED)
-        .body(ErrorResponse.of(ApiErrorCode.UNAUTHORIZED.getMessage(),
-            ApiErrorCode.UNAUTHORIZED.getCode()));
+        .body(ErrorResponse.from(ApiErrorCode.UNAUTHORIZED));
   }
 
   @ExceptionHandler(ConstraintViolationException.class)
@@ -135,8 +134,7 @@ public class GlobalExceptionHandler {
     log(e, request, UNAUTHORIZED);
     return ResponseEntity
         .status(UNAUTHORIZED)
-        .body(ErrorResponse.of(ApiErrorCode.UNAUTHORIZED.getMessage(),
-            ApiErrorCode.UNAUTHORIZED.getCode()));
+        .body(ErrorResponse.from(ApiErrorCode.UNAUTHORIZED));
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
@@ -145,7 +143,7 @@ public class GlobalExceptionHandler {
 
     HttpStatus status = BAD_REQUEST;
     log(e, request, status);
-    return ResponseEntity.status(status).body(ErrorResponse.from(e));
+    return ResponseEntity.status(status).body(ErrorResponse.of(e.getMessage(), ApiErrorCode.INVALID_REQUEST.getCode()));
   }
 
   @ExceptionHandler(IllegalStateException.class)
@@ -154,7 +152,7 @@ public class GlobalExceptionHandler {
 
     HttpStatus status = BAD_REQUEST;
     log(e, request, status);
-    return ResponseEntity.status(status).body(ErrorResponse.from(e));
+    return ResponseEntity.status(status).body(ErrorResponse.of(e.getMessage(), ApiErrorCode.INVALID_REQUEST.getCode()));
   }
 
   @ExceptionHandler(Exception.class)
@@ -163,7 +161,7 @@ public class GlobalExceptionHandler {
 
     HttpStatus status = INTERNAL_SERVER_ERROR;
     log(e, request, status);
-    return ResponseEntity.status(status).body(ErrorResponse.from(e));
+    return ResponseEntity.status(status).body(ErrorResponse.from(ApiErrorCode.INTERNAL_SERVER_ERROR));
   }
 
   @ExceptionHandler(Throwable.class)
@@ -172,7 +170,7 @@ public class GlobalExceptionHandler {
 
     HttpStatus status = INTERNAL_SERVER_ERROR;
     log(e, request, status);
-    return ResponseEntity.status(status).body(ErrorResponse.from(e));
+    return ResponseEntity.status(status).body(ErrorResponse.from(ApiErrorCode.INTERNAL_SERVER_ERROR));
   }
 
   private static void log(Throwable e, HttpServletRequest request, HttpStatus status) {

--- a/back/src/main/java/com/rouby/schedule/application/exception/ScheduleErrorCode.java
+++ b/back/src/main/java/com/rouby/schedule/application/exception/ScheduleErrorCode.java
@@ -1,0 +1,20 @@
+package com.rouby.schedule.application.exception;
+
+import com.rouby.common.exception.type.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ScheduleErrorCode implements ErrorCode {
+  SCHEDULE_INVALID_REQUEST(
+      "유효하지 않은 요청 정보입니다.",
+      "SCHEDULE_INVALID_REQUEST",
+      HttpStatus.UNPROCESSABLE_ENTITY),
+  ;
+  private final String message;
+  private final String code;
+  private final HttpStatus status;
+}

--- a/back/src/main/java/com/rouby/schedule/application/exception/ScheduleException.java
+++ b/back/src/main/java/com/rouby/schedule/application/exception/ScheduleException.java
@@ -1,0 +1,19 @@
+package com.rouby.schedule.application.exception;
+
+import com.rouby.common.exception.CustomException;
+import com.rouby.common.exception.type.ErrorCode;
+
+public class ScheduleException extends CustomException {
+
+  private ScheduleException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  private ScheduleException(ErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
+
+  public static ScheduleException of(ErrorCode errorCode, String message) {
+    return new ScheduleException(errorCode, message);
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/application/service/ScheduleReadService.java
+++ b/back/src/main/java/com/rouby/schedule/application/service/ScheduleReadService.java
@@ -2,6 +2,8 @@ package com.rouby.schedule.application.service;
 
 import com.rouby.schedule.application.dto.info.SchedulesInfo;
 import com.rouby.schedule.application.dto.query.GetScheduleQuery;
+import com.rouby.schedule.application.exception.ScheduleErrorCode;
+import com.rouby.schedule.application.exception.ScheduleException;
 import com.rouby.schedule.domain.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +15,10 @@ public class ScheduleReadService {
   private final ScheduleRepository scheduleRepository;
 
   public SchedulesInfo findSchedulesBy(GetScheduleQuery query) {
-    return SchedulesInfo.of(scheduleRepository.findSchedulesByCriteria(query.toCriteria()));
+    try {
+      return SchedulesInfo.of(scheduleRepository.findSchedulesByCriteria(query.toCriteria()));
+    } catch (IllegalArgumentException e) {
+      throw ScheduleException.of(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST, e.getMessage());
+    }
   }
 }

--- a/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
+++ b/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
@@ -1,6 +1,8 @@
 package com.rouby.schedule.application.service;
 
 import com.rouby.schedule.application.dto.command.CreateScheduleCommand;
+import com.rouby.schedule.application.exception.ScheduleErrorCode;
+import com.rouby.schedule.application.exception.ScheduleException;
 import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +16,13 @@ public class ScheduleWriteService {
 
   public Long createSchedule(Long userId, CreateScheduleCommand command) {
 
-    Schedule schedule = command.toEntityWithUserId(userId);
-    scheduleRepository.save(schedule);
+    try {
+      Schedule schedule = command.toEntityWithUserId(userId);
+      scheduleRepository.save(schedule);
+      return schedule.getId();
 
-    return schedule.getId();
+    } catch (IllegalArgumentException e) {
+      throw ScheduleException.of(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST, e.getMessage());
+    }
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
@@ -8,11 +8,13 @@ import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class OverrideInfo {
 
   @Enumerated(EnumType.STRING)

--- a/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
@@ -33,9 +33,12 @@ public class RecurrenceRule implements Serializable {
 
   @Enumerated(EnumType.STRING)
   private Freq freq;
+
   @Convert(converter = ByDaySetConverter.class)
   private Set<ByDay> byDay;
+
   private Integer interval;
+
   private LocalDateTime until;
 
   @Builder

--- a/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
@@ -8,6 +8,8 @@ import com.rouby.schedule.domain.support.UntilDateTimeFormatter;
 import io.jsonwebtoken.lang.Assert;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -29,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecurrenceRule implements Serializable {
 
+  @Enumerated(EnumType.STRING)
   private Freq freq;
   @Convert(converter = ByDaySetConverter.class)
   private Set<ByDay> byDay;

--- a/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepositoryCustomImpl.java
@@ -12,6 +12,7 @@ import com.rouby.schedule.domain.repository.info.ScheduleWithOverrides;
 import com.rouby.schedule.domain.repository.info.ScheduleWithOverrides.ScheduleOverride;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -88,6 +89,7 @@ public class ScheduleJpaRepositoryCustomImpl implements ScheduleJpaRepositoryCus
                               .overrideDate(t.get(child.overrideInfo.overrideDate))
                               .build()
                           )
+                          .sorted(Comparator.comparing(ScheduleOverride::startAt))
                           .toList();
 
                       return ScheduleWithOverrides.builder()

--- a/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepositoryCustomImpl.java
@@ -27,36 +27,38 @@ public class ScheduleJpaRepositoryCustomImpl implements ScheduleJpaRepositoryCus
   public List<ScheduleWithOverrides> findSchedulesByCriteria(GetScheduleCriteria criteria) {
 
     List<Tuple> tuples = jpaQueryFactory.select(
-        schedule.id,
-        schedule.userId,
-        schedule.title,
-        schedule.memo,
-        schedule.period.startAt,
-        schedule.period.endAt,
-        schedule.routineOffsetDays,
-        schedule.alarmOffsetType,
-        schedule.recurrenceRule,
-        child.id,
-        child.userId,
-        child.title,
-        child.memo,
-        child.period.startAt,
-        child.period.endAt,
-        child.routineOffsetDays,
-        child.alarmOffsetType,
-        child.overrideInfo.overrideType,
-        child.overrideInfo.overrideDate)
+            schedule.id,
+            schedule.userId,
+            schedule.title,
+            schedule.memo,
+            schedule.period.startAt,
+            schedule.period.endAt,
+            schedule.routineOffsetDays,
+            schedule.alarmOffsetType,
+            schedule.recurrenceRule,
+            child.id,
+            child.userId,
+            child.title,
+            child.memo,
+            child.period.startAt,
+            child.period.endAt,
+            child.routineOffsetDays,
+            child.alarmOffsetType,
+            child.overrideInfo.overrideType,
+            child.overrideInfo.overrideDate)
         .from(schedule)
         .leftJoin(child)
         .on(
             schedule.recurrenceRule.isNotNull()
                 .and(child.deletedAt.isNull())
                 .and(child.parentSchedule.eq(schedule))
+                .and(startAtBeforeToAt(child, criteria.toAt()))
+                .and(endAtAfterFromAt(child, criteria.fromAt()))
         )
-        .where(buildWhereClause(criteria))
-        .orderBy(schedule.period.startAt.asc())
+        .where(buildWhereClause(schedule, criteria))
+        .orderBy(schedule.userId.asc(), schedule.period.startAt.asc())
         .fetch();
-    
+
     return convertGroupedList(tuples);
   }
 
@@ -107,41 +109,42 @@ public class ScheduleJpaRepositoryCustomImpl implements ScheduleJpaRepositoryCus
         ));
   }
 
-  private BooleanBuilder buildWhereClause(GetScheduleCriteria criteria) {
-    return eqUserId(criteria.userId())
-        .and(schedule.deletedAt.isNull())
-        .and(schedule.overrideInfo.overrideType.isNull())
-        .and(recurringCriteria(criteria).or(singleCriteria(criteria)));
+  private BooleanBuilder buildWhereClause(QSchedule s, GetScheduleCriteria criteria) {
+
+    return eqUserId(s, criteria.userId())
+        .and(s.deletedAt.isNull())
+        .and(s.overrideInfo.overrideType.isNull())
+        .and(recurringCriteria(s, criteria).or(singleCriteria(s, criteria)));
   }
 
-  private BooleanBuilder recurringCriteria(GetScheduleCriteria criteria) {
+  private BooleanBuilder recurringCriteria(QSchedule s, GetScheduleCriteria criteria) {
 
-    return new BooleanBuilder().and(schedule.recurrenceRule.isNotNull())
-        .and(startAtBeforeToAt(criteria.toAt()))
-        .and(schedule.recurrenceRule.until.isNull()
-            .or(untilAtAfterFromAt(criteria.fromAt())));
+    return new BooleanBuilder(s.recurrenceRule.isNotNull())
+        .and(startAtBeforeToAt(s, criteria.toAt()))
+        .and(s.recurrenceRule.until.isNull()
+            .or(untilAtAfterFromAt(s, criteria.fromAt())));
   }
 
-  private BooleanBuilder singleCriteria(GetScheduleCriteria criteria) {
+  private BooleanBuilder singleCriteria(QSchedule s, GetScheduleCriteria criteria) {
 
-    return new BooleanBuilder().and(schedule.recurrenceRule.isNull())
-        .and(startAtBeforeToAt(criteria.toAt()))
-        .and(endAtAfterFromAt(criteria.fromAt()));
+    return new BooleanBuilder(s.recurrenceRule.isNull())
+        .and(startAtBeforeToAt(s, criteria.toAt()))
+        .and(endAtAfterFromAt(s, criteria.fromAt()));
   }
 
-  private static BooleanBuilder startAtBeforeToAt(LocalDateTime toAt) {
-    return nullSafeBuilder(() -> schedule.period.startAt.before(toAt));
+  private static BooleanBuilder startAtBeforeToAt(QSchedule s, LocalDateTime toAt) {
+    return nullSafeBuilder(() -> s.period.startAt.before(toAt));
   }
 
-  private static BooleanBuilder untilAtAfterFromAt(LocalDateTime fromAt) {
-    return nullSafeBuilder(() -> schedule.recurrenceRule.until.after(fromAt));
+  private static BooleanBuilder untilAtAfterFromAt(QSchedule s, LocalDateTime fromAt) {
+    return nullSafeBuilder(() -> s.recurrenceRule.until.after(fromAt));
   }
 
-  private static BooleanBuilder endAtAfterFromAt(LocalDateTime fromAt) {
-    return nullSafeBuilder(() -> schedule.period.endAt.after(fromAt));
+  private static BooleanBuilder endAtAfterFromAt(QSchedule s, LocalDateTime fromAt) {
+    return nullSafeBuilder(() -> s.period.endAt.after(fromAt));
   }
 
-  private BooleanBuilder eqUserId(Long userId)  {
-    return nullSafeBuilder(() -> schedule.userId.eq(userId));
+  private BooleanBuilder eqUserId(QSchedule s, Long userId)  {
+    return nullSafeBuilder(() -> s.userId.eq(userId));
   }
 }

--- a/back/src/main/resources/db/schema.sql
+++ b/back/src/main/resources/db/schema.sql
@@ -1,0 +1,6 @@
+-- SCHEDULE
+ALTER TABLE schedule ALTER COLUMN id SET DEFAULT nextval('schedule_seq');
+DROP INDEX IF EXISTS idx_schedule_parent_not_deleted;
+CREATE INDEX idx_schedule_parent_not_deleted
+    ON schedule(parent_schedule_id)
+    WHERE deleted_at IS NULL;

--- a/back/src/main/resources/properties/datasource.yml
+++ b/back/src/main/resources/properties/datasource.yml
@@ -2,7 +2,7 @@
 spring:
   config.activate.on-profile: local
   datasource:
-    url: jdbc:postgresql://localhost:5432/rouby
+    url: jdbc:postgresql://localhost:5432/rouby?rewriteBatchedInserts=true
     username: postgres
     password: postgres
     driver-class-name: org.postgresql.Driver
@@ -11,14 +11,11 @@ spring:
         rewriteBatchedInserts: true
         # rewriteBatchedStatements: true # mysql 용
         # schema: rouby
-  jdbc:
-    batch:
-      size: 10000
   sql:
     init:
-      mode: never
-      # schema-locations: classpath:db/schema.sql
-      # data-locations: classpath:db/alter.sql # db 시작할때 실행시킬 script
+      mode: always
+      schema-locations: classpath:db/schema.sql
+      #data-locations: classpath:db/data.sql
 
 ---
 # test 환경

--- a/back/src/test/java/com/rouby/schedule/data/JdbcTestDataRepository.java
+++ b/back/src/test/java/com/rouby/schedule/data/JdbcTestDataRepository.java
@@ -1,0 +1,82 @@
+package com.rouby.schedule.data;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rouby.schedule.domain.entity.Schedule;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class JdbcTestDataRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+
+  @Transactional
+  public void batchInsert(int batchSize, List<Schedule> list) {
+
+    var sql = """
+        INSERT INTO schedule 
+        (user_id, parent_schedule_id
+        , title, memo, routine_offset_days, start_at, end_at
+        , alarm_offset_type, override_type, override_date, recurrence_rule
+        , created_at, created_by, updated_at, updated_by)
+        VALUES
+        (?, ?
+        , ?, ?, ?, ?, ?
+        , ?, ?, ?, ?::jsonb
+        , NOW(), ?, NOW(), ?)
+        """;
+
+    try {
+      jdbcTemplate.batchUpdate(
+          sql,
+          list,
+          batchSize,
+          (ps, arg) -> {
+            ps.setLong(1, arg.getUserId());
+            ps.setObject(2,
+                arg.getParentSchedule() == null ? null : arg.getParentSchedule().getId(),
+                Types.BIGINT);
+            ps.setString(3, arg.getTitle());
+            ps.setString(4, arg.getMemo());
+            ps.setInt(5, arg.getRoutineOffsetDays());
+            ps.setTimestamp(6, Timestamp.valueOf(arg.getPeriod().getStartAt()));
+            ps.setTimestamp(7, Timestamp.valueOf(arg.getPeriod().getEndAt()));
+            ps.setObject(8,
+                arg.getAlarmOffsetType() == null ? null : arg.getAlarmOffsetType().name(),
+                Types.VARCHAR);
+            ps.setObject(9,
+                arg.getOverrideInfo() == null ? null : arg.getOverrideInfo().getOverrideType().name(),
+                Types.VARCHAR);
+            ps.setObject(10,
+                arg.getOverrideInfo() == null ? null : Date.valueOf(
+                    arg.getOverrideInfo().getOverrideDate()),
+                Types.DATE);
+            ps.setObject(11,
+                arg.getRecurrenceRule() == null ? null: getString(arg.getRecurrenceRule()).replace("byDay", "by_day"),
+                Types.VARCHAR);
+            ps.setLong(12, arg.getUserId());
+            ps.setLong(13, arg.getUserId());
+          });
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw e;
+    }
+  }
+
+  private String getString(Object object) {
+
+    try {
+      return objectMapper.writeValueAsString(object);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/back/src/test/java/com/rouby/schedule/data/JdbcTestDataRepository.java
+++ b/back/src/test/java/com/rouby/schedule/data/JdbcTestDataRepository.java
@@ -59,7 +59,10 @@ public class JdbcTestDataRepository {
                     arg.getOverrideInfo().getOverrideDate()),
                 Types.DATE);
             ps.setObject(11,
-                arg.getRecurrenceRule() == null ? null: getString(arg.getRecurrenceRule()).replace("byDay", "by_day"),
+                arg.getRecurrenceRule() == null
+                    ? null
+                    : toJsonString(arg.getRecurrenceRule())
+                        .replaceAll("\"byDay\":", "\"by_day\":"),
                 Types.VARCHAR);
             ps.setLong(12, arg.getUserId());
             ps.setLong(13, arg.getUserId());
@@ -71,7 +74,7 @@ public class JdbcTestDataRepository {
     }
   }
 
-  private String getString(Object object) {
+  private String toJsonString(Object object) {
 
     try {
       return objectMapper.writeValueAsString(object);

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataFactory.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataFactory.java
@@ -8,27 +8,50 @@ import com.rouby.schedule.domain.vo.Period;
 import com.rouby.schedule.domain.vo.RecurrenceRule;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.springframework.test.util.ReflectionTestUtils;
+
 
 public class ScheduleTestDataFactory {
 
-  public static List<Schedule> generateTestSchedules(int count) {
-    List<Schedule> schedules = new ArrayList<>();
-    for (int i = 0; i < count; i++) {
-      schedules.add(createSchedule(i));
+  private static final int MAX_USER_COUNT = 1_000;
+  private static List<Schedule> overridesResult;
+
+  public static List<Schedule> generateTestSchedules(int offset, int count) {
+    List<Schedule> schedulesResult = new ArrayList<>(count);
+    overridesResult = new ArrayList<>(count / 4 * 10);
+
+    for (int i = offset; i < offset + count; i++) {
+
+      Schedule schedule = createSchedule(i);
+
+      List<Schedule> overrides = Collections.emptyList();
+      if (i % 4 == 0) {
+        int finalI = i;
+        overrides = IntStream.range(0, 10)
+            .mapToObj(j -> createScheduleOverride(schedule, finalI, j))
+            .toList();
+        overridesResult.addAll(overrides);
+       // ReflectionTestUtils.setField(schedule, "children", overrides);
+      }
+      schedulesResult.add(schedule);
+      schedulesResult.addAll(overrides);
     }
-    return schedules;
+    return schedulesResult;
   }
 
   private static Schedule createSchedule(int index) {
+    long userId = (index % MAX_USER_COUNT) + 1;
+
     Schedule schedule = Schedule.builder()
-        .userId((long) (index % 5 + 1))
+        .userId(userId)
         .title("테스트 일정 " + index)
         .memo("자동 생성된 메모 " + index)
         .period(Period.builder()
-            .startAt(LocalDate.now().minusMonths(2).atStartOfDay().plusDays(index))
-            .endAt(LocalDate.now().minusMonths(2).atStartOfDay().plusDays(index + 1))
+            .startAt(LocalDate.now().minusMonths(2).atStartOfDay().plusDays(index / MAX_USER_COUNT))
+            .endAt(LocalDate.now().minusMonths(2).atStartOfDay().plusDays(index / MAX_USER_COUNT + 1))
             .build())
         .alarmOffsetMinutes(60)
         .recurrenceRule(index % 2 == 0
@@ -39,29 +62,25 @@ public class ScheduleTestDataFactory {
             : null
         )
         .build();
-
     ReflectionTestUtils.setField(schedule, "routineOffsetDays", 3);
-    if (index % 4 == 0) {
-      ReflectionTestUtils.setField(schedule, "children", List.of(createScheduleOverride(schedule, index)));
-    }
     return schedule;
   }
 
-  private static Schedule createScheduleOverride(Schedule parent, int index) {
+  private static Schedule createScheduleOverride(Schedule parent, int index, int offset) {
     Schedule override = Schedule.builder()
         .userId(parent.getUserId())
-        .title("예외 일정 " + index)
+        .title("예외 일정 " + index / MAX_USER_COUNT + "-" + offset)
         .memo("예외 메모")
         .period(Period.builder()
-            .startAt(parent.getPeriod().getStartAt().plusWeeks(4).plusDays(1))
-            .endAt(parent.getPeriod().getEndAt().plusWeeks(4).plusDays(1))
+            .startAt(parent.getPeriod().getStartAt().plusWeeks(4 + offset).plusDays(1))
+            .endAt(parent.getPeriod().getEndAt().plusWeeks(4 + offset).plusDays(1))
             .build()
         )
         .alarmOffsetMinutes(60)
         .build();
 
     ReflectionTestUtils.setField(override, "overrideInfo", OverrideInfo.builder()
-        .overrideDate(parent.getPeriod().getStartAt().plusWeeks(4).toLocalDate())
+        .overrideDate(parent.getPeriod().getStartAt().plusWeeks(4 + offset).toLocalDate())
         .overrideType(OverrideType.MODIFIED)
         .build()
     );
@@ -69,5 +88,12 @@ public class ScheduleTestDataFactory {
     ReflectionTestUtils.setField(override, "parentSchedule", parent);
 
     return override;
+  }
+
+  public static void removeReferenceWith() {
+//    schedulesResult.stream().filter(schedule -> schedule.getChildren() != null)
+//        .forEach(schedule -> ReflectionTestUtils.setField(schedule, "children", null));
+
+    overridesResult.forEach(override -> ReflectionTestUtils.setField(override, "parentSchedule", null));
   }
 }

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataFactory.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataFactory.java
@@ -17,24 +17,25 @@ import org.springframework.test.util.ReflectionTestUtils;
 public class ScheduleTestDataFactory {
 
   private static final int MAX_USER_COUNT = 1_000;
-  private static List<Schedule> overridesResult;
+
+  private static final int OVERRIDE_FREQUENCY = 4; // 4개 중 1개에 override 생성
+  private static final int OVERRIDES_PER_SCHEDULE = 10;
 
   public static List<Schedule> generateTestSchedules(int offset, int count) {
     List<Schedule> schedulesResult = new ArrayList<>(count);
-    overridesResult = new ArrayList<>(count / 4 * 10);
+    List<Schedule> overridesResult = new ArrayList<>(count / 4 * 10);
 
     for (int i = offset; i < offset + count; i++) {
 
       Schedule schedule = createSchedule(i);
 
       List<Schedule> overrides = Collections.emptyList();
-      if (i % 4 == 0) {
+      if (i % OVERRIDE_FREQUENCY == 0) {
         int finalI = i;
-        overrides = IntStream.range(0, 10)
+        overrides = IntStream.range(0, OVERRIDES_PER_SCHEDULE)
             .mapToObj(j -> createScheduleOverride(schedule, finalI, j))
             .toList();
         overridesResult.addAll(overrides);
-       // ReflectionTestUtils.setField(schedule, "children", overrides);
       }
       schedulesResult.add(schedule);
       schedulesResult.addAll(overrides);
@@ -88,12 +89,5 @@ public class ScheduleTestDataFactory {
     ReflectionTestUtils.setField(override, "parentSchedule", parent);
 
     return override;
-  }
-
-  public static void removeReferenceWith() {
-//    schedulesResult.stream().filter(schedule -> schedule.getChildren() != null)
-//        .forEach(schedule -> ReflectionTestUtils.setField(schedule, "children", null));
-
-    overridesResult.forEach(override -> ReflectionTestUtils.setField(override, "parentSchedule", null));
   }
 }

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
@@ -33,10 +33,18 @@ public class ScheduleTestDataSaver {
 
     JdbcTestDataRepository repository = new JdbcTestDataRepository(jdbcTemplate, objectMapper);
     List<Schedule> schedules;
-    for (int i = 0; i < maxSize; i += batchSize) {
 
-      schedules = ScheduleTestDataFactory.generateTestSchedules(i, batchSize);
-      repository.batchInsert(batchSize, schedules);
+    for (int i = 0; i < maxSize; i += batchSize) {
+      try {
+        schedules = ScheduleTestDataFactory.generateTestSchedules(i, batchSize);
+        repository.batchInsert(batchSize, schedules);
+        System.out.printf("Inserted batch %d-%d%n", i, i + batchSize);
+
+      } catch (Exception e) {
+
+        System.err.printf("Failed to insert batch %d-%d: %s%n", i, i + batchSize, e.getMessage());
+        break;
+      }
     }
   }
 }

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
@@ -1,5 +1,6 @@
 package com.rouby.schedule.data;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.repository.ScheduleRepository;
 import java.util.List;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
 @SpringBootTest
@@ -16,11 +18,25 @@ public class ScheduleTestDataSaver {
   @Autowired
   private ScheduleRepository scheduleRepository;
 
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
   @Test
   @DisplayName("스케쥴 기본 데이터 생성")
   void createSchedules() {
 
-    List<Schedule> schedules = ScheduleTestDataFactory.generateTestSchedules(100);
-    scheduleRepository.saveAll(schedules);
+    int batchSize = 100;
+    int maxSize = 1_000_000; // * 3 정도의 데이터 생성됨
+
+    JdbcTestDataRepository repository = new JdbcTestDataRepository(jdbcTemplate, objectMapper);
+    List<Schedule> schedules;
+    for (int i = 0; i < maxSize; i += batchSize) {
+
+      schedules = ScheduleTestDataFactory.generateTestSchedules(i, batchSize);
+      repository.batchInsert(batchSize, schedules);
+    }
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #92

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 테스트 데이터 추가 로직 개선
  - [x] 쿼리 보완 및 인덱스 추가
  - [x] 글로벌 예외 처리, 커스텀 익셉션 보완
  - [x] 일정 예외 처리 일부 보완

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- 인덱스 관련 정리: https://www.notion.so/23b67f8e83278094847cc18aa8f4574a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 일정 관련 도메인 예외 및 에러 코드(ScheduleException, ScheduleErrorCode) 추가.
  * 테스트 데이터 대량 삽입용 JdbcTestDataRepository 클래스 추가.

* **버그 수정**
  * 일정 생성 및 조회 시 잘못된 요청에 대해 도메인 예외로 변환하여 처리.

* **개선 및 리팩터링**
  * 에러 응답 생성 방식 표준화.
  * Lombok 어노테이션(@Getter) 및 enum 저장 방식 개선.
  * 쿼리 빌더 구조 개선 및 정렬 방식 변경.

* **테스트**
  * 테스트 데이터 생성 방식 개선 및 대량 데이터 배치 삽입 지원.
  * 테스트 유틸리티 메서드 추가.

* **설정 및 문서**
  * 데이터베이스 스키마 및 데이터소스 설정 개선, 인덱스 및 배치 옵션 적용.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->