### PR TITLE
[#120][be][schedule] Schedule 테스트 코드 수정

### DIFF
--- a/back/src/test/java/com/rouby/schedule/data/JdbcTestDataRepository.java
+++ b/back/src/test/java/com/rouby/schedule/data/JdbcTestDataRepository.java
@@ -78,7 +78,7 @@ public class JdbcTestDataRepository {
         });
   }
 
-  public List<Long> fetchNextIds(String sequenceName, int count) {
+  public List<Long> fetchNextIds(int count) {
     String sql = "SELECT nextval('schedule_seq') FROM generate_series(1, ?)";
     return jdbcTemplate.query(
         sql,

--- a/back/src/test/java/com/rouby/schedule/data/JdbcTestDataRepository.java
+++ b/back/src/test/java/com/rouby/schedule/data/JdbcTestDataRepository.java
@@ -18,60 +18,75 @@ public class JdbcTestDataRepository {
   private final ObjectMapper objectMapper;
 
   @Transactional
-  public void batchInsert(int batchSize, List<Schedule> list) {
+  public void batchInsert(int batchSize, List<Schedule> schedules) {
 
     var sql = """
         INSERT INTO schedule 
-        (user_id, parent_schedule_id
+        (id, user_id, parent_schedule_id
         , title, memo, routine_offset_days, start_at, end_at
         , alarm_offset_type, override_type, override_date, recurrence_rule
         , created_at, created_by, updated_at, updated_by)
         VALUES
-        (?, ?
+        (?, ?, ?
         , ?, ?, ?, ?, ?
         , ?, ?, ?, ?::jsonb
         , NOW(), ?, NOW(), ?)
         """;
-
     try {
-      jdbcTemplate.batchUpdate(
-          sql,
-          list,
-          batchSize,
-          (ps, arg) -> {
-            ps.setLong(1, arg.getUserId());
-            ps.setObject(2,
-                arg.getParentSchedule() == null ? null : arg.getParentSchedule().getId(),
-                Types.BIGINT);
-            ps.setString(3, arg.getTitle());
-            ps.setString(4, arg.getMemo());
-            ps.setInt(5, arg.getRoutineOffsetDays());
-            ps.setTimestamp(6, Timestamp.valueOf(arg.getPeriod().getStartAt()));
-            ps.setTimestamp(7, Timestamp.valueOf(arg.getPeriod().getEndAt()));
-            ps.setObject(8,
-                arg.getAlarmOffsetType() == null ? null : arg.getAlarmOffsetType().name(),
-                Types.VARCHAR);
-            ps.setObject(9,
-                arg.getOverrideInfo() == null ? null : arg.getOverrideInfo().getOverrideType().name(),
-                Types.VARCHAR);
-            ps.setObject(10,
-                arg.getOverrideInfo() == null ? null : Date.valueOf(
-                    arg.getOverrideInfo().getOverrideDate()),
-                Types.DATE);
-            ps.setObject(11,
-                arg.getRecurrenceRule() == null
-                    ? null
-                    : toJsonString(arg.getRecurrenceRule())
-                        .replaceAll("\"byDay\":", "\"by_day\":"),
-                Types.VARCHAR);
-            ps.setLong(12, arg.getUserId());
-            ps.setLong(13, arg.getUserId());
-          });
-
+        batchUpdateSchedules(sql, batchSize, schedules);
     } catch (Exception e) {
       e.printStackTrace();
       throw e;
     }
+
+  }
+
+  private void batchUpdateSchedules(String sql, int batchSize, List<Schedule> schedules) {
+    jdbcTemplate.batchUpdate(
+        sql,
+        schedules,
+        batchSize,
+        (ps, arg) -> {
+          ps.setLong(1, arg.getId());
+          ps.setLong(2, arg.getUserId());
+          ps.setObject(3,
+              arg.getParentSchedule() == null ? null : arg.getParentSchedule().getId(),
+              Types.BIGINT);
+          ps.setString(4, arg.getTitle());
+          ps.setString(5, arg.getMemo());
+          ps.setInt(6, arg.getRoutineOffsetDays());
+          ps.setTimestamp(7, Timestamp.valueOf(arg.getPeriod().getStartAt()));
+          ps.setTimestamp(8, Timestamp.valueOf(arg.getPeriod().getEndAt()));
+          ps.setObject(9,
+              arg.getAlarmOffsetType() == null ? null : arg.getAlarmOffsetType().name(),
+              Types.VARCHAR);
+          ps.setObject(10,
+              arg.getOverrideInfo() == null ? null : arg.getOverrideInfo().getOverrideType().name(),
+              Types.VARCHAR);
+          ps.setObject(11,
+              arg.getOverrideInfo() == null ? null : Date.valueOf(
+                  arg.getOverrideInfo().getOverrideDate()),
+              Types.DATE);
+          ps.setObject(12,
+              arg.getRecurrenceRule() == null
+                  ? null
+                  : toJsonString(arg.getRecurrenceRule())
+                      .replaceAll("\"byDay\":", "\"by_day\":"),
+              Types.VARCHAR);
+          ps.setLong(13, arg.getUserId());
+          ps.setLong(14, arg.getUserId());
+        });
+  }
+
+  public List<Long> fetchNextIds(String sequenceName, int count) {
+    String sql = "SELECT nextval('schedule_seq') FROM generate_series(1, ?)";
+    return jdbcTemplate.query(
+        sql,
+        ps -> {
+          ps.setInt(1, count);
+        },
+        (rs, rowNum) -> rs.getLong(1)
+    );
   }
 
   private String toJsonString(Object object) {

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataFactory.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataFactory.java
@@ -10,7 +10,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.testcontainers.shaded.org.apache.commons.lang3.tuple.Pair;
 
 
 public class ScheduleTestDataFactory {
@@ -19,28 +18,29 @@ public class ScheduleTestDataFactory {
   private static final int OVERRIDE_FREQUENCY = 4; // 4개 중 1개에 override 생성
   private static final int OVERRIDES_PER_SCHEDULE = 10;
 
-public static List<Schedule> generateTestSchedules(int offset, int count,
-    List<Long> scheduleIds, int startIdx) {
-  List<Schedule> schedulesResult = new ArrayList<>(count + count / OVERRIDE_FREQUENCY * OVERRIDES_PER_SCHEDULE);
+  public static List<Schedule> generateTestSchedules(int offset, int count,
+      List<Long> scheduleIds, int startIdx) {
+    List<Schedule> schedulesResult = new ArrayList<>(
+        count + count / OVERRIDE_FREQUENCY * OVERRIDES_PER_SCHEDULE);
 
-  for (int i = offset; i < offset + count; i++) {
+    for (int i = offset; i < offset + count; i++) {
 
-    // 부모 Schedule 생성
-    Schedule schedule = createSchedule(i, scheduleIds.get(startIdx++));
-    schedulesResult.add(schedule);
+      // 부모 Schedule 생성
+      Schedule schedule = createSchedule(i, scheduleIds.get(startIdx++));
+      schedulesResult.add(schedule);
 
-    // 자식 Schedule (예외) 생성
-    if (i % OVERRIDE_FREQUENCY == 0) {
-      for (int j = 0; j < OVERRIDES_PER_SCHEDULE; j++) {
-        Long childId = scheduleIds.get(startIdx++);
-        Schedule override = createScheduleOverride(schedule, i, j, childId);
-        schedulesResult.add(override);
+      // 자식 Schedule (예외) 생성
+      if (i % OVERRIDE_FREQUENCY == 0) {
+        for (int j = 0; j < OVERRIDES_PER_SCHEDULE; j++) {
+          Long childId = scheduleIds.get(startIdx++);
+          Schedule override = createScheduleOverride(schedule, i, j, childId);
+          schedulesResult.add(override);
+        }
       }
     }
-  }
 
-  return schedulesResult;
-}
+    return schedulesResult;
+  }
 
   private static Schedule createSchedule(int index, Long id) {
     long userId = (index % MAX_USER_COUNT) + 1;

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataFactory.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataFactory.java
@@ -8,42 +8,41 @@ import com.rouby.schedule.domain.vo.Period;
 import com.rouby.schedule.domain.vo.RecurrenceRule;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.IntStream;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.shaded.org.apache.commons.lang3.tuple.Pair;
 
 
 public class ScheduleTestDataFactory {
 
   private static final int MAX_USER_COUNT = 1_000;
-
   private static final int OVERRIDE_FREQUENCY = 4; // 4개 중 1개에 override 생성
   private static final int OVERRIDES_PER_SCHEDULE = 10;
 
-  public static List<Schedule> generateTestSchedules(int offset, int count) {
-    List<Schedule> schedulesResult = new ArrayList<>(count);
-    List<Schedule> overridesResult = new ArrayList<>(count / 4 * 10);
+public static List<Schedule> generateTestSchedules(int offset, int count,
+    List<Long> scheduleIds, int startIdx) {
+  List<Schedule> schedulesResult = new ArrayList<>(count + count / OVERRIDE_FREQUENCY * OVERRIDES_PER_SCHEDULE);
 
-    for (int i = offset; i < offset + count; i++) {
+  for (int i = offset; i < offset + count; i++) {
 
-      Schedule schedule = createSchedule(i);
+    // 부모 Schedule 생성
+    Schedule schedule = createSchedule(i, scheduleIds.get(startIdx++));
+    schedulesResult.add(schedule);
 
-      List<Schedule> overrides = Collections.emptyList();
-      if (i % OVERRIDE_FREQUENCY == 0) {
-        int finalI = i;
-        overrides = IntStream.range(0, OVERRIDES_PER_SCHEDULE)
-            .mapToObj(j -> createScheduleOverride(schedule, finalI, j))
-            .toList();
-        overridesResult.addAll(overrides);
+    // 자식 Schedule (예외) 생성
+    if (i % OVERRIDE_FREQUENCY == 0) {
+      for (int j = 0; j < OVERRIDES_PER_SCHEDULE; j++) {
+        Long childId = scheduleIds.get(startIdx++);
+        Schedule override = createScheduleOverride(schedule, i, j, childId);
+        schedulesResult.add(override);
       }
-      schedulesResult.add(schedule);
-      schedulesResult.addAll(overrides);
     }
-    return schedulesResult;
   }
 
-  private static Schedule createSchedule(int index) {
+  return schedulesResult;
+}
+
+  private static Schedule createSchedule(int index, Long id) {
     long userId = (index % MAX_USER_COUNT) + 1;
 
     Schedule schedule = Schedule.builder()
@@ -52,7 +51,8 @@ public class ScheduleTestDataFactory {
         .memo("자동 생성된 메모 " + index)
         .period(Period.builder()
             .startAt(LocalDate.now().minusMonths(2).atStartOfDay().plusDays(index / MAX_USER_COUNT))
-            .endAt(LocalDate.now().minusMonths(2).atStartOfDay().plusDays(index / MAX_USER_COUNT + 1))
+            .endAt(
+                LocalDate.now().minusMonths(2).atStartOfDay().plusDays(index / MAX_USER_COUNT + 1))
             .build())
         .alarmOffsetMinutes(60)
         .recurrenceRule(index % 2 == 0
@@ -63,14 +63,16 @@ public class ScheduleTestDataFactory {
             : null
         )
         .build();
+
+    ReflectionTestUtils.setField(schedule, "id", id);
     ReflectionTestUtils.setField(schedule, "routineOffsetDays", 3);
     return schedule;
   }
 
-  private static Schedule createScheduleOverride(Schedule parent, int index, int offset) {
+  private static Schedule createScheduleOverride(Schedule parent, int index, int offset, Long id) {
     Schedule override = Schedule.builder()
         .userId(parent.getUserId())
-        .title("예외 일정 " + index / MAX_USER_COUNT + "-" + offset)
+        .title("예외 일정 " + index + "-" + offset)
         .memo("예외 메모")
         .period(Period.builder()
             .startAt(parent.getPeriod().getStartAt().plusWeeks(4 + offset).plusDays(1))
@@ -80,6 +82,7 @@ public class ScheduleTestDataFactory {
         .alarmOffsetMinutes(60)
         .build();
 
+    ReflectionTestUtils.setField(override, "id", id);
     ReflectionTestUtils.setField(override, "overrideInfo", OverrideInfo.builder()
         .overrideDate(parent.getPeriod().getStartAt().plusWeeks(4 + offset).toLocalDate())
         .overrideType(OverrideType.MODIFIED)
@@ -89,5 +92,10 @@ public class ScheduleTestDataFactory {
     ReflectionTestUtils.setField(override, "parentSchedule", parent);
 
     return override;
+  }
+
+  public static int getCountSchedules(int count) {
+    int overrideCount = (count / OVERRIDE_FREQUENCY) * OVERRIDES_PER_SCHEDULE;
+    return count + overrideCount;
   }
 }

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
@@ -3,15 +3,16 @@ package com.rouby.schedule.data;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.repository.ScheduleRepository;
+import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.shaded.org.apache.commons.lang3.tuple.Pair;
 
-@Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
+//@Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
 @SpringBootTest
 public class ScheduleTestDataSaver {
 
@@ -29,15 +30,22 @@ public class ScheduleTestDataSaver {
   void createSchedules() {
 
     int batchSize = 100;
-    int maxSize = 1_000_000; // * 3 정도의 데이터 생성됨
+    int maxSize = 1_000; // * 3 정도의 데이터 생성됨
 
     JdbcTestDataRepository repository = new JdbcTestDataRepository(jdbcTemplate, objectMapper);
     List<Schedule> schedules;
+    int totalSize = ScheduleTestDataFactory.getCountSchedules(maxSize);
+
+    List<Long> ids = repository.fetchNextIds("schedule_id_seq", totalSize);
+
+    int idIndex = 0;
 
     for (int i = 0; i < maxSize; i += batchSize) {
       try {
-        schedules = ScheduleTestDataFactory.generateTestSchedules(i, batchSize);
+        schedules = ScheduleTestDataFactory.generateTestSchedules(i, batchSize, ids, idIndex);
         repository.batchInsert(batchSize, schedules);
+        idIndex += ScheduleTestDataFactory.getCountSchedules(Math.min(batchSize, maxSize - i));
+
         System.out.printf("Inserted batch %d-%d%n", i, i + batchSize);
 
       } catch (Exception e) {

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
@@ -3,16 +3,15 @@ package com.rouby.schedule.data;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.repository.ScheduleRepository;
-import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.testcontainers.shaded.org.apache.commons.lang3.tuple.Pair;
 
-//@Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
+@Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
 @SpringBootTest
 public class ScheduleTestDataSaver {
 

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
@@ -35,7 +35,7 @@ public class ScheduleTestDataSaver {
     List<Schedule> schedules;
     int totalSize = ScheduleTestDataFactory.getCountSchedules(maxSize);
 
-    List<Long> ids = repository.fetchNextIds("schedule_id_seq", totalSize);
+    List<Long> ids = repository.fetchNextIds(totalSize);
 
     int idIndex = 0;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #120 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
   - bulkInsert시 부모참조 및 예외 일정 부모인덱스 잘못 설정됨

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 자식 객체가 부모객체 참조하도록 수정
  - [ ]예외 일정에 부모인덱스 수정
  - [ ] TODO

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
<img width="1070" height="628" alt="image" src="https://github.com/user-attachments/assets/586eb546-7c70-4366-a200-3311baf74997" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 테스트 데이터 생성 시 스케줄 ID를 명시적으로 할당할 수 있도록 개선되었습니다.
  * 대량의 테스트 스케줄을 생성할 때 데이터베이스 시퀀스를 통해 필요한 ID 목록을 미리 가져오도록 변경되었습니다.
  * 스케줄 및 오버라이드 스케줄의 총 개수를 계산하는 유틸리티 기능이 추가되었습니다.

* **성능 및 안정성 개선**
  * 테스트 데이터 최대 생성 개수가 1,000,000개에서 1,000개로 축소되어 실행 속도와 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->