### PR TITLE
[#96][be][notification] 알림 전송 코드 보완

### DIFF
--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmMessageHelper.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmMessageHelper.java
@@ -24,7 +24,22 @@ public class FcmMessageHelper {
     this.iconUri = iconUri;
   }
 
-  public Message buildMessage(NotificationEvent event) {
+  public Message buildCustomMessage(NotificationEvent event) {
+
+    return Message.builder()
+        .setToken(event.getDeviceTokenInfo().getDeviceToken())
+        .putData("title", event.getMessage().getTitle())
+        .putData("body",  event.getMessage().getBody())
+        .putData("icon",  appUrl + iconUri)
+        .putData("url", event.getMessage().getUrl())
+        .setWebpushConfig(
+            WebpushConfig.builder()
+            .putHeader("TTL", String.valueOf(Duration.ofHours(1).toSeconds()))
+            .build())
+        .build();
+  }
+
+  public Message buildBasicNotificationMessage(NotificationEvent event) {
 
     Notification notification = buildNotification(event);
     WebpushConfig webpushConfig = buildWebpushConfig(event);
@@ -32,7 +47,6 @@ public class FcmMessageHelper {
     return Message.builder()
         .setToken(event.getDeviceTokenInfo().getDeviceToken())
         .setNotification(notification)
-        .putData("url", event.getMessage().getUrl())
         .setWebpushConfig(webpushConfig)
         .build();
   }
@@ -54,6 +68,7 @@ public class FcmMessageHelper {
   }
 
   private WebpushFcmOptions buildFcmOptions(NotificationEvent event) {
+
     return WebpushFcmOptions.builder()
         .setLink(event.getMessage().getUrl())
         .build();
@@ -65,6 +80,7 @@ public class FcmMessageHelper {
         .setTitle(event.getMessage().getTitle())
         .setBody(event.getMessage().getBody())
         .setIcon(appUrl + iconUri)
+        .putCustomData("url", event.getMessage().getUrl())
         .build();
   }
 }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmMessageHelper.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmMessageHelper.java
@@ -7,11 +7,14 @@ import com.google.firebase.messaging.WebpushFcmOptions;
 import com.google.firebase.messaging.WebpushNotification;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
 import java.time.Duration;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FcmMessageHelper {
+
+  private static final String TTL_SECONDS = String.valueOf(Duration.ofHours(1).toSeconds());
 
   private final String appUrl;
   private final String iconUri;
@@ -28,14 +31,13 @@ public class FcmMessageHelper {
 
     return Message.builder()
         .setToken(event.getDeviceTokenInfo().getDeviceToken())
-        .putData("title", event.getMessage().getTitle())
-        .putData("body",  event.getMessage().getBody())
-        .putData("icon",  appUrl + iconUri)
-        .putData("url", event.getMessage().getUrl())
-        .setWebpushConfig(
-            WebpushConfig.builder()
-            .putHeader("TTL", String.valueOf(Duration.ofHours(1).toSeconds()))
-            .build())
+        .putData("title", Objects.toString(event.getMessage().getTitle(), ""))
+        .putData("body",  Objects.toString(event.getMessage().getBody(), ""))
+        .putData("icon",  (iconUri.startsWith("http")
+            ? iconUri
+            : appUrl + (iconUri.startsWith("/") ? iconUri : ("/" + iconUri))))
+        .putData("url",   Objects.toString(event.getMessage().getUrl(), ""))
+        .setWebpushConfig(buildWebpushConfig())
         .build();
   }
 
@@ -51,10 +53,16 @@ public class FcmMessageHelper {
         .build();
   }
 
+  private WebpushConfig buildWebpushConfig() {
+    return WebpushConfig.builder()
+        .putHeader("TTL", TTL_SECONDS)
+        .build();
+  }
+
   private WebpushConfig buildWebpushConfig(NotificationEvent event) {
     return WebpushConfig.builder()
         .setNotification(buildWebpushNotification(event))
-        .putHeader("TTL", String.valueOf(Duration.ofHours(1).toSeconds()))
+        .putHeader("TTL", TTL_SECONDS)
         .setFcmOptions(buildFcmOptions(event))
         .build();
   }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FirebaseNotificationSender.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FirebaseNotificationSender.java
@@ -22,7 +22,7 @@ public class FirebaseNotificationSender implements NotificationSender {
   @Override
   public void send(NotificationEvent event) {
 
-    Message message = fcmMessageHelper.buildMessage(event);
+    Message message = fcmMessageHelper.buildCustomMessage(event);
 
     try {
       firebaseMessaging.send(message);

--- a/back/src/main/java/com/rouby/user/device/domain/entity/UserDevice.java
+++ b/back/src/main/java/com/rouby/user/device/domain/entity/UserDevice.java
@@ -3,6 +3,7 @@ package com.rouby.user.device.domain.entity;
 import com.rouby.user.device.domain.entity.vo.DeviceInfo;
 import com.rouby.user.device.domain.entity.vo.DeviceTokenInfo;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,8 +37,10 @@ public class UserDevice {
   @Column(nullable = false)
   private Long userId;
 
+  @Embedded
   private DeviceTokenInfo tokenInfo;
 
+  @Embedded
   private DeviceInfo deviceInfo;
 
   @CreatedDate

--- a/back/src/main/resources/properties/base.yml
+++ b/back/src/main/resources/properties/base.yml
@@ -10,7 +10,6 @@ app:
   front-url: 'http://localhost:5173'
   icon-uri: '/assets/header_logo.svg'
 
-
 ---
 # test 환경
 spring:
@@ -23,3 +22,4 @@ server:
 app:
   front-url: 'http://localhost:5173'
   icon-uri: '/assets/header_logo.svg'
+


### PR DESCRIPTION
## #️⃣연관된 이슈
- #96

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  -  fcm 알림을 보낼 때 notification 을 보냄

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 커스터마이징을 위해 notification 제거

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 푸시 알림에 제목·본문·아이콘·URL(딥링크)이 포함되어 더 풍부한 표시와 바로가기 이동이 가능합니다.
  - 웹 푸시에 TTL 설정이 반영되어 알림 전달 신뢰성이 향상되었습니다.

- 기타
  - 내부 구성 및 매핑 정리로 안정성이 개선되었습니다. 사용자 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->