### PR TITLE
[#214][be][user] 유저 디바이스 및 토큰 정보 삭제 api 추가

### DIFF
--- a/back/src/docs/asciidoc/user-device.adoc
+++ b/back/src/docs/asciidoc/user-device.adoc
@@ -26,3 +26,47 @@ include::{snippets}/register-user-device-invalid-request-400/http-request.adoc[]
 include::{snippets}/register-user-device-invalid-request-400/http-response.adoc[]
 
 ---
+
+
+[[Delete-UserDevice]]
+== 유저 기기 정보 삭제 API
+
+=== 성공: 유저 기기 정보 삭제 요청
+
+==== HTTP 요청
+include::{snippets}/delete-user-device-204/http-request.adoc[]
+
+==== 요청 필드
+include::{snippets}/delete-user-device-204/request-fields.adoc[]
+
+==== HTTP 응답 (204 No Content)
+include::{snippets}/delete-user-device-204/http-response.adoc[]
+
+=== 실패: 유효성 검증 오류
+
+==== 토큰 제공자 정보 오류
+
+===== HTTP 요청
+include::{snippets}/delete-user-device-invalid-request-400/http-request.adoc[]
+
+===== HTTP 응답 (400 Bad Request)
+include::{snippets}/delete-user-device-invalid-request-400/http-response.adoc[]
+
+---
+
+
+[[Delete-All-UserDevice]]
+== 유저 기기 정보 전체 삭제 API
+
+=== 성공: 유저 기기 정보 전체 삭제 요청
+
+==== HTTP 요청
+include::{snippets}/delete-all-user-device-204/http-request.adoc[]
+
+==== 요청 필드
+include::{snippets}/delete-all-user-device-204/request-fields.adoc[]
+
+==== HTTP 응답 (204 No Content)
+include::{snippets}/delete-all-user-device-204/http-response.adoc[]
+
+---

--- a/back/src/main/java/com/rouby/user/device/application/dto/command/DeleteUserDeviceCommand.java
+++ b/back/src/main/java/com/rouby/user/device/application/dto/command/DeleteUserDeviceCommand.java
@@ -1,0 +1,11 @@
+package com.rouby.user.device.application.dto.command;
+
+import lombok.Builder;
+
+@Builder
+public record DeleteUserDeviceCommand(
+    Long userId,
+    String deviceToken,
+    String tokenProvider
+) {
+}

--- a/back/src/main/java/com/rouby/user/device/application/exception/UserDeviceErrorCode.java
+++ b/back/src/main/java/com/rouby/user/device/application/exception/UserDeviceErrorCode.java
@@ -1,0 +1,18 @@
+package com.rouby.user.device.application.exception;
+
+import com.rouby.common.exception.type.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum UserDeviceErrorCode implements ErrorCode {
+  NOT_FOUND_USER_DEVICE("조건에 해당하는 유저 디바이스 정보가 존재하지 않습니다.", "NOT_FOUND_USER_DEVICE", HttpStatus.NOT_FOUND),
+  ;
+
+  private final String message;
+  private final String code;
+  private final HttpStatus status;
+}

--- a/back/src/main/java/com/rouby/user/device/application/facade/UserDeviceFacade.java
+++ b/back/src/main/java/com/rouby/user/device/application/facade/UserDeviceFacade.java
@@ -16,11 +16,11 @@ public class UserDeviceFacade {
     userDeviceWriteService.register(command);
   }
 
-  public void delete(DeleteUserDeviceCommand command) {
+  public void hardDelete(DeleteUserDeviceCommand command) {
     userDeviceWriteService.hardDelete(command);
   }
 
-  public void deleteAllByUser(Long userId) {
+  public void hardDeleteAllByUser(Long userId) {
     userDeviceWriteService.hardDeleteAllByUser(userId);
   }
 }

--- a/back/src/main/java/com/rouby/user/device/application/facade/UserDeviceFacade.java
+++ b/back/src/main/java/com/rouby/user/device/application/facade/UserDeviceFacade.java
@@ -1,5 +1,6 @@
 package com.rouby.user.device.application.facade;
 
+import com.rouby.user.device.application.dto.command.DeleteUserDeviceCommand;
 import com.rouby.user.device.application.dto.command.RegisterUserDeviceCommand;
 import com.rouby.user.device.application.service.UserDeviceWriteService;
 import lombok.RequiredArgsConstructor;
@@ -13,5 +14,13 @@ public class UserDeviceFacade {
 
   public void register(RegisterUserDeviceCommand command) {
     userDeviceWriteService.register(command);
+  }
+
+  public void delete(DeleteUserDeviceCommand command) {
+    userDeviceWriteService.hardDelete(command);
+  }
+
+  public void deleteAllByUser(Long userId) {
+    userDeviceWriteService.hardDeleteAllByUser(userId);
   }
 }

--- a/back/src/main/java/com/rouby/user/device/application/scheduler/UserDeviceScheduler.java
+++ b/back/src/main/java/com/rouby/user/device/application/scheduler/UserDeviceScheduler.java
@@ -19,7 +19,7 @@ public class UserDeviceScheduler {
   public void deleteStaleDeviceTokens() {
 
     try {
-      int deletedCnt = userDeviceWriteService.deleteStaleDeviceTokens(STALE_THRESHOLD);
+      int deletedCnt = userDeviceWriteService.hardDeleteStaleDeviceTokens(STALE_THRESHOLD);
       log.info("::stale device tokens:: {} 건 삭제되었습니다.", deletedCnt);
     } catch (Exception e) {
       log.error(e.getMessage(), e);

--- a/back/src/main/java/com/rouby/user/device/application/scheduler/UserDeviceScheduler.java
+++ b/back/src/main/java/com/rouby/user/device/application/scheduler/UserDeviceScheduler.java
@@ -2,18 +2,23 @@ package com.rouby.user.device.application.scheduler;
 
 import com.rouby.user.device.application.service.UserDeviceWriteService;
 import java.time.Period;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class UserDeviceScheduler {
 
-  private static final Period STALE_THRESHOLD = Period.ofDays(60);
+  private final Period STALE_THRESHOLD;
   private final UserDeviceWriteService userDeviceWriteService;
+
+  public UserDeviceScheduler(@Value("${user-device.stale-threshold-days:60}") Period staleThreshold, UserDeviceWriteService userDeviceWriteService) {
+    this.STALE_THRESHOLD = staleThreshold;
+    this.userDeviceWriteService = userDeviceWriteService;
+  }
+
 
   @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
   public void deleteStaleDeviceTokens() {

--- a/back/src/main/java/com/rouby/user/device/application/service/UserDeviceWriteService.java
+++ b/back/src/main/java/com/rouby/user/device/application/service/UserDeviceWriteService.java
@@ -1,6 +1,10 @@
 package com.rouby.user.device.application.service;
 
+import com.rouby.common.exception.CustomException;
+import com.rouby.user.device.application.dto.command.DeleteUserDeviceCommand;
 import com.rouby.user.device.application.dto.command.RegisterUserDeviceCommand;
+import com.rouby.user.device.application.exception.UserDeviceErrorCode;
+import com.rouby.user.device.domain.entity.enums.TokenProviderType;
 import com.rouby.user.device.domain.repository.UserDeviceRepository;
 import java.time.LocalDateTime;
 import java.time.Period;
@@ -26,8 +30,23 @@ public class UserDeviceWriteService {
   }
 
   @Transactional
-  public int deleteStaleDeviceTokens(Period staleThreshold) {
+  public int hardDeleteStaleDeviceTokens(Period staleThreshold) {
+
     LocalDateTime threshold = LocalDateTime.now().minus(staleThreshold);
     return userDeviceRepository.deleteByLastActiveAtBefore(threshold);
+  }
+
+  @Transactional
+  public void hardDelete(DeleteUserDeviceCommand command) {
+
+    int result = userDeviceRepository.deleteByUserIdAndTokenInfo_deviceTokenAndTokenInfo_tokenProvider(
+        command.userId(), command.deviceToken(), TokenProviderType.parse(command.tokenProvider()));
+    if (result < 1) throw CustomException.from(UserDeviceErrorCode.NOT_FOUND_USER_DEVICE);
+  }
+
+  @Transactional
+  public void hardDeleteAllByUser(Long userId) {
+
+    userDeviceRepository.deleteAllByUserId(userId);
   }
 }

--- a/back/src/main/java/com/rouby/user/device/domain/repository/UserDeviceRepository.java
+++ b/back/src/main/java/com/rouby/user/device/domain/repository/UserDeviceRepository.java
@@ -22,5 +22,5 @@ public interface UserDeviceRepository {
   int deleteByUserIdAndTokenInfo_deviceTokenAndTokenInfo_tokenProvider(
       Long userId, String deviceToken, TokenProviderType tokenProvider);
 
-  void deleteAllByUserId(Long userId);
+  int deleteAllByUserId(Long userId);
 }

--- a/back/src/main/java/com/rouby/user/device/domain/repository/UserDeviceRepository.java
+++ b/back/src/main/java/com/rouby/user/device/domain/repository/UserDeviceRepository.java
@@ -1,6 +1,7 @@
 package com.rouby.user.device.domain.repository;
 
 import com.rouby.user.device.domain.entity.UserDevice;
+import com.rouby.user.device.domain.entity.enums.TokenProviderType;
 import com.rouby.user.device.domain.entity.vo.DeviceInfo;
 import com.rouby.user.device.domain.entity.vo.DeviceTokenInfo;
 import java.time.LocalDateTime;
@@ -17,4 +18,9 @@ public interface UserDeviceRepository {
   UserDevice saveAndFlush(UserDevice userDevice);
 
   int upsertUserDevice(Long userId, DeviceTokenInfo tokenInfo, DeviceInfo info);
+
+  int deleteByUserIdAndTokenInfo_deviceTokenAndTokenInfo_tokenProvider(
+      Long userId, String deviceToken, TokenProviderType tokenProvider);
+
+  void deleteAllByUserId(Long userId);
 }

--- a/back/src/main/java/com/rouby/user/device/presentation/UserDeviceController.java
+++ b/back/src/main/java/com/rouby/user/device/presentation/UserDeviceController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,22 +34,22 @@ public class UserDeviceController {
   }
 
   @PreAuthorize("hasAnyRole('USER')")
-  @PatchMapping("/delete")
+  @DeleteMapping
   public ResponseEntity<Void> deleteUserDevice(
       @AuthenticationPrincipal SecurityUser securityUser,
-      @RequestBody @Validated DeleteUserDeviceRequest request) {
+      @Validated DeleteUserDeviceRequest request) {
 
-    userDeviceFacade.delete(request.toCommand(securityUser.getId()));
+    userDeviceFacade.hardDelete(request.toCommand(securityUser.getId()));
 
     return ResponseEntity.noContent().build();
   }
 
   @PreAuthorize("hasAnyRole('USER')")
-  @PatchMapping("/delete/all")
-  public ResponseEntity<Void> deleteUserDevice(
+  @DeleteMapping("/all")
+  public ResponseEntity<Void> deleteAllUserDevice(
       @AuthenticationPrincipal SecurityUser securityUser) {
 
-    userDeviceFacade.deleteAllByUser(securityUser.getId());
+    userDeviceFacade.hardDeleteAllByUser(securityUser.getId());
 
     return ResponseEntity.noContent().build();
   }

--- a/back/src/main/java/com/rouby/user/device/presentation/UserDeviceController.java
+++ b/back/src/main/java/com/rouby/user/device/presentation/UserDeviceController.java
@@ -1,6 +1,7 @@
 package com.rouby.user.device.presentation;
 
 import com.rouby.user.device.application.facade.UserDeviceFacade;
+import com.rouby.user.device.presentation.dto.request.DeleteUserDeviceRequest;
 import com.rouby.user.device.presentation.dto.request.RegisterUserDeviceRequest;
 import com.rouby.user.user.infrastructure.security.dto.SecurityUser;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +29,27 @@ public class UserDeviceController {
       @RequestBody @Validated RegisterUserDeviceRequest request) {
 
     userDeviceFacade.register(request.toCommand(securityUser.getId()));
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @PreAuthorize("hasAnyRole('USER')")
+  @PatchMapping("/delete")
+  public ResponseEntity<Void> deleteUserDevice(
+      @AuthenticationPrincipal SecurityUser securityUser,
+      @RequestBody @Validated DeleteUserDeviceRequest request) {
+
+    userDeviceFacade.delete(request.toCommand(securityUser.getId()));
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @PreAuthorize("hasAnyRole('USER')")
+  @PatchMapping("/delete/all")
+  public ResponseEntity<Void> deleteUserDevice(
+      @AuthenticationPrincipal SecurityUser securityUser) {
+
+    userDeviceFacade.deleteAllByUser(securityUser.getId());
 
     return ResponseEntity.noContent().build();
   }

--- a/back/src/main/java/com/rouby/user/device/presentation/dto/request/DeleteUserDeviceRequest.java
+++ b/back/src/main/java/com/rouby/user/device/presentation/dto/request/DeleteUserDeviceRequest.java
@@ -1,0 +1,24 @@
+package com.rouby.user.device.presentation.dto.request;
+
+import com.rouby.user.device.application.dto.command.DeleteUserDeviceCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import org.hibernate.validator.constraints.Length;
+
+@Builder
+public record DeleteUserDeviceRequest(
+    @NotBlank @Length(max=50) @Pattern(regexp = "(?i)^(FCM|APNs)$")
+    String tokenProvider,
+    @NotBlank @Length(max=500) String deviceToken
+) {
+
+  public DeleteUserDeviceCommand toCommand(Long userId) {
+
+    return DeleteUserDeviceCommand.builder()
+        .userId(userId)
+        .tokenProvider(tokenProvider)
+        .deviceToken(deviceToken)
+        .build();
+  }
+}

--- a/back/src/main/java/com/rouby/user/user/application/UserFacade.java
+++ b/back/src/main/java/com/rouby/user/user/application/UserFacade.java
@@ -9,6 +9,7 @@ import com.rouby.common.props.URIProperty;
 import com.rouby.common.utils.CodeGenerator;
 import com.rouby.notification.email.application.exception.EmailException;
 import com.rouby.notification.email.application.service.EmailService;
+import com.rouby.user.device.application.service.UserDeviceWriteService;
 import com.rouby.user.user.application.dto.command.CreateUserCommand;
 import com.rouby.user.user.application.dto.command.FindPasswordCommand;
 import com.rouby.user.user.application.dto.command.LoginCommand;
@@ -34,6 +35,7 @@ public class UserFacade {
 
   private final UserReadService userReadService;
   private final UserWriteService userWriteService;
+  private final UserDeviceWriteService userDeviceWriteService;
   private final EmailService emailService;
   private final URIProperty uriProperty;
 
@@ -117,5 +119,6 @@ public class UserFacade {
   }
   public void delete(Long userId) {
     userWriteService.delete(userId);
+    userDeviceWriteService.hardDeleteAllByUser(userId);
   }
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
       - classpath:properties/crypto.yml
       - classpath:properties/firebase.yml
       - classpath:properties/setting.yml
+      - classpath:properties/schedule.yml
   profiles:
     group:
       local: local

--- a/back/src/main/resources/properties/schedule.yml
+++ b/back/src/main/resources/properties/schedule.yml
@@ -1,0 +1,10 @@
+# local 환경
+spring:
+  config.activate.on-profile: local
+user-device:
+  stale-threshold-days: 60
+
+---
+# test 환경
+spring:
+  config.activate.on-profile: test

--- a/back/src/test/http/http-client.env.json
+++ b/back/src/test/http/http-client.env.json
@@ -4,9 +4,9 @@
     "valid-email": "valid@hidle.com",
     "valid-password": "aaaaaa11!",
     "valid-email-verification-code": "code",
-    "access_token": "token",
+    "access_token": "token"
   },
   "prod": {
-    "url": "http://...:8080",
+    "url": "http://...:8080"
   }
 }

--- a/back/src/test/http/user_device.http
+++ b/back/src/test/http/user_device.http
@@ -15,16 +15,10 @@ Authorization: Bearer {{access_token}}
 
 
 ###
-PATCH {{url}}/api/v1/users/devices/delete
-content-type: application/json
+DELETE {{url}}/api/v1/users/devices?tokenProvider=FCM&deviceToken=1234
 Authorization: Bearer {{access_token}}
-
-{
-  "tokenProvider": "FCM",
-  "deviceToken": "1234"
-}
 
 
 ###
-PATCH {{url}}/api/v1/users/devices/delete/all
+DELETE {{url}}/api/v1/users/devices/all
 Authorization: Bearer {{access_token}}

--- a/back/src/test/http/user_device.http
+++ b/back/src/test/http/user_device.http
@@ -12,3 +12,19 @@ Authorization: Bearer {{access_token}}
   "browser": "string",
   "userAgent": "string"
 }
+
+
+###
+PATCH {{url}}/api/v1/users/devices/delete
+content-type: application/json
+Authorization: Bearer {{access_token}}
+
+{
+  "tokenProvider": "FCM",
+  "deviceToken": "1234"
+}
+
+
+###
+PATCH {{url}}/api/v1/users/devices/delete/all
+Authorization: Bearer {{access_token}}

--- a/back/src/test/java/com/rouby/user/device/fixture/UserDeviceFixture.java
+++ b/back/src/test/java/com/rouby/user/device/fixture/UserDeviceFixture.java
@@ -1,5 +1,6 @@
 package com.rouby.user.device.fixture;
 
+import com.rouby.user.device.presentation.dto.request.DeleteUserDeviceRequest;
 import com.rouby.user.device.presentation.dto.request.RegisterUserDeviceRequest;
 
 public class UserDeviceFixture {
@@ -27,6 +28,20 @@ public class UserDeviceFixture {
         .os("Windows")
         .browser("Safari")
         .userAgent("test")
+        .build();
+  }
+
+  public static DeleteUserDeviceRequest getInvalidDeviceTypeDeleteRequest() {
+    return DeleteUserDeviceRequest.builder()
+        .deviceToken("1234")
+        .tokenProvider("dkfjg")
+        .build();
+  }
+
+  public static DeleteUserDeviceRequest getSuccessDeleteRequest() {
+    return DeleteUserDeviceRequest.builder()
+        .deviceToken("1234")
+        .tokenProvider("FCM")
         .build();
   }
 }

--- a/back/src/test/java/com/rouby/user/device/fixture/UserDeviceFixture.java
+++ b/back/src/test/java/com/rouby/user/device/fixture/UserDeviceFixture.java
@@ -1,6 +1,5 @@
 package com.rouby.user.device.fixture;
 
-import com.rouby.user.device.presentation.dto.request.DeleteUserDeviceRequest;
 import com.rouby.user.device.presentation.dto.request.RegisterUserDeviceRequest;
 
 public class UserDeviceFixture {
@@ -28,20 +27,6 @@ public class UserDeviceFixture {
         .os("Windows")
         .browser("Safari")
         .userAgent("test")
-        .build();
-  }
-
-  public static DeleteUserDeviceRequest getInvalidDeviceTypeDeleteRequest() {
-    return DeleteUserDeviceRequest.builder()
-        .deviceToken("1234")
-        .tokenProvider("dkfjg")
-        .build();
-  }
-
-  public static DeleteUserDeviceRequest getSuccessDeleteRequest() {
-    return DeleteUserDeviceRequest.builder()
-        .deviceToken("1234")
-        .tokenProvider("FCM")
         .build();
   }
 }

--- a/back/src/test/java/com/rouby/user/device/presentation/UserDeviceControllerTest.java
+++ b/back/src/test/java/com/rouby/user/device/presentation/UserDeviceControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -16,7 +17,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.rouby.common.security.WithMockCustomUser;
 import com.rouby.common.support.ControllerTestSupport;
+import com.rouby.user.device.application.dto.command.DeleteUserDeviceCommand;
 import com.rouby.user.device.fixture.UserDeviceFixture;
+import com.rouby.user.device.presentation.dto.request.DeleteUserDeviceRequest;
 import com.rouby.user.device.presentation.dto.request.RegisterUserDeviceRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,6 +91,88 @@ class UserDeviceControllerTest extends ControllerTestSupport {
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
             getValidationErrorResponseFieldSnippet()
+        ));
+  }
+
+  @WithMockCustomUser
+  @Test
+  @DisplayName("회원 디바이스 정보 삭제 API - 성공")
+  void deleteUserDevice() throws Exception {
+    DeleteUserDeviceRequest request = UserDeviceFixture.getSuccessDeleteRequest();
+    String content = objectMapper.writeValueAsString(request);
+
+    doNothing().when(userDeviceFacade).delete(any(DeleteUserDeviceCommand.class));
+
+    ResultActions resultActions = mockMvc.perform(patch("/api/v1/users/devices/delete")
+        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+        .content(content)
+        .characterEncoding("UTF-8")
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    verify(userDeviceFacade).delete(any(DeleteUserDeviceCommand.class));
+
+    resultActions.andExpect(status().isNoContent())
+        .andDo(print())
+        .andDo(document("delete-user-device-204",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("deviceToken").description("기기 토큰"),
+                fieldWithPath("tokenProvider").description("토큰 제공자")
+            )
+        ));
+  }
+
+  @WithMockCustomUser
+  @DisplayName("회원 디바이스 정보 삭제 API - 유효하지 못한 요청으로 실패 400")
+  @Test
+  void deleteUserDevice_failed_request() throws Exception {
+
+    // given
+    DeleteUserDeviceRequest request = UserDeviceFixture.getInvalidDeviceTypeDeleteRequest();
+    String content = objectMapper.writeValueAsString(request);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(patch("/api/v1/users/devices/delete")
+        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+        .content(content)
+        .characterEncoding("UTF-8")
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    verify(userDeviceFacade, never()).delete(any());
+
+    resultActions.andExpect(status().isBadRequest())
+        .andDo(print())
+        .andDo(document("delete-user-device-invalid-request-400",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            getValidationErrorResponseFieldSnippet()
+        ));
+  }
+
+  @WithMockCustomUser
+  @Test
+  @DisplayName("회원 디바이스 정보 전체 삭제 API - 성공")
+  void deleteAllUserDevice() throws Exception {
+
+    doNothing().when(userDeviceFacade).deleteAllByUser(any());
+
+    ResultActions resultActions = mockMvc.perform(patch("/api/v1/users/devices/delete/all")
+        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+        .characterEncoding("UTF-8")
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    verify(userDeviceFacade).deleteAllByUser(any());
+
+    resultActions.andExpect(status().isNoContent())
+        .andDo(print())
+        .andDo(document("delete-all-user-device-204"
         ));
   }
 }

--- a/back/src/test/java/com/rouby/user/device/presentation/UserDeviceControllerTest.java
+++ b/back/src/test/java/com/rouby/user/device/presentation/UserDeviceControllerTest.java
@@ -5,13 +5,15 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -19,12 +21,15 @@ import com.rouby.common.security.WithMockCustomUser;
 import com.rouby.common.support.ControllerTestSupport;
 import com.rouby.user.device.application.dto.command.DeleteUserDeviceCommand;
 import com.rouby.user.device.fixture.UserDeviceFixture;
-import com.rouby.user.device.presentation.dto.request.DeleteUserDeviceRequest;
 import com.rouby.user.device.presentation.dto.request.RegisterUserDeviceRequest;
+import java.net.URI;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
 
 class UserDeviceControllerTest extends ControllerTestSupport {
 
@@ -98,29 +103,38 @@ class UserDeviceControllerTest extends ControllerTestSupport {
   @Test
   @DisplayName("회원 디바이스 정보 삭제 API - 성공")
   void deleteUserDevice() throws Exception {
-    DeleteUserDeviceRequest request = UserDeviceFixture.getSuccessDeleteRequest();
-    String content = objectMapper.writeValueAsString(request);
 
-    doNothing().when(userDeviceFacade).delete(any(DeleteUserDeviceCommand.class));
+    // given
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("tokenProvider", "fcm");
+    params.add("deviceToken", "1234");
 
-    ResultActions resultActions = mockMvc.perform(patch("/api/v1/users/devices/delete")
+    URI uri = UriComponentsBuilder
+        .fromPath("/api/v1/users/devices")
+        .queryParams(params)
+        .build(true)
+        .toUri();
+
+    doNothing().when(userDeviceFacade).hardDelete(any(DeleteUserDeviceCommand.class));
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        delete(uri)
         .header("Authorization", "Bearer {ACCESS_TOKEN}")
-        .content(content)
         .characterEncoding("UTF-8")
-        .contentType(MediaType.APPLICATION_JSON)
     );
 
     // then
-    verify(userDeviceFacade).delete(any(DeleteUserDeviceCommand.class));
+    verify(userDeviceFacade).hardDelete(any(DeleteUserDeviceCommand.class));
 
     resultActions.andExpect(status().isNoContent())
         .andDo(print())
         .andDo(document("delete-user-device-204",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
-            requestFields(
-                fieldWithPath("deviceToken").description("기기 토큰"),
-                fieldWithPath("tokenProvider").description("토큰 제공자")
+            queryParameters(
+                parameterWithName("tokenProvider").description("토큰 제공자(FCM/APNs)"),
+                parameterWithName("deviceToken").description("사용자 디바이스 토큰")
             )
         ));
   }
@@ -131,19 +145,19 @@ class UserDeviceControllerTest extends ControllerTestSupport {
   void deleteUserDevice_failed_request() throws Exception {
 
     // given
-    DeleteUserDeviceRequest request = UserDeviceFixture.getInvalidDeviceTypeDeleteRequest();
-    String content = objectMapper.writeValueAsString(request);
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("tokenProvider", "random");
+    params.add("deviceToken", "1234");
 
     // when
-    ResultActions resultActions = mockMvc.perform(patch("/api/v1/users/devices/delete")
+    ResultActions resultActions = mockMvc.perform(delete("/api/v1/users/devices")
+        .params(params)
         .header("Authorization", "Bearer {ACCESS_TOKEN}")
-        .content(content)
         .characterEncoding("UTF-8")
-        .contentType(MediaType.APPLICATION_JSON)
     );
 
     // then
-    verify(userDeviceFacade, never()).delete(any());
+    verify(userDeviceFacade, never()).hardDelete(any());
 
     resultActions.andExpect(status().isBadRequest())
         .andDo(print())
@@ -159,16 +173,16 @@ class UserDeviceControllerTest extends ControllerTestSupport {
   @DisplayName("회원 디바이스 정보 전체 삭제 API - 성공")
   void deleteAllUserDevice() throws Exception {
 
-    doNothing().when(userDeviceFacade).deleteAllByUser(any());
+    doNothing().when(userDeviceFacade).hardDeleteAllByUser(any());
 
-    ResultActions resultActions = mockMvc.perform(patch("/api/v1/users/devices/delete/all")
+    ResultActions resultActions = mockMvc.perform(delete("/api/v1/users/devices/all")
         .header("Authorization", "Bearer {ACCESS_TOKEN}")
         .characterEncoding("UTF-8")
         .contentType(MediaType.APPLICATION_JSON)
     );
 
     // then
-    verify(userDeviceFacade).deleteAllByUser(any());
+    verify(userDeviceFacade).hardDeleteAllByUser(any());
 
     resultActions.andExpect(status().isNoContent())
         .andDo(print())


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #214

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  
- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 유저 디바이스 및 토큰 정보 삭제 api 추가
  - [x] 유저 디바이스 및 토큰 정보 삭제 api  테스트 코드 추가
  - [x] 회원 탈퇴시 유저의 디바이스 토큰 정보 모두 삭제 처리

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 사용자 기기 삭제 기능 추가: 단일 기기 삭제 및 모든 기기 일괄 삭제 엔드포인트 제공(응답 204).
* 개선
  * 오래된 기기 토큰 정리 작업을 영구 삭제 방식으로 일관화.
  * 사용자 계정 삭제 시 연결된 모든 기기 토큰 자동 제거.
* 버그 수정
  * HTTP 클라이언트 환경 JSON의 문법 오류(후행 쉼표) 수정.
* 테스트
  * 기기 삭제 엔드포인트에 대한 통합/검증 테스트 및 HTTP 시나리오 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->