### PR TITLE
[#216][fe][user] 회원 탈퇴시 피니아 초기화

### DIFF
--- a/front/src/features/auth/dto.js
+++ b/front/src/features/auth/dto.js
@@ -19,7 +19,6 @@ export function toVerifyCodePayload(email, code) {
 }
 
 export function toVerifyPasswordCodePayload(form) {
-  console.log('dto', form)
   return {
     email: form.email?.trim(),
     token: form.token?.trim(),

--- a/front/src/features/user/useMyPageForm.js
+++ b/front/src/features/user/useMyPageForm.js
@@ -40,6 +40,7 @@ export function useMyPageForm() {
       const success = await withdrawalOfUser()
       if (success) {
         resetAllStores()
+        removeStorageFlagForPinia()
         goTo({ name: 'login' })
       }
     } catch (err) {

--- a/front/src/features/user/useMyPageForm.js
+++ b/front/src/features/user/useMyPageForm.js
@@ -37,10 +37,11 @@ export function useMyPageForm() {
   const onConfirmWithdraw = async () => {
     isWithdrawing.value = true
     try {
+      resetAllStores()
+      removeStorageFlagForPinia()
+
       const success = await withdrawalOfUser()
       if (success) {
-        resetAllStores()
-        removeStorageFlagForPinia()
         goTo({ name: 'login' })
       }
     } catch (err) {

--- a/front/src/features/user/useMyPageForm.js
+++ b/front/src/features/user/useMyPageForm.js
@@ -2,6 +2,7 @@ import { ref, reactive, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { withdrawalOfUser } from '@/features/user/userService.js'
 import { useUserInfoStore } from '@/stores/useUserInfoStore'
+import { resetAllStores } from '@/shared/utils/piniaUtils'
 
 export function useMyPageForm() {
   const router = useRouter()
@@ -38,6 +39,7 @@ export function useMyPageForm() {
     try {
       const success = await withdrawalOfUser()
       if (success) {
+        resetAllStores()
         goTo({ name: 'login' })
       }
     } catch (err) {

--- a/front/src/shared/utils/piniaPersistUtils.js
+++ b/front/src/shared/utils/piniaPersistUtils.js
@@ -1,0 +1,36 @@
+const PINIA_STATE_KEY = 'pinia-state'
+
+export function getPiniaStorage() {
+  try {
+    const raw =
+      localStorage.getItem(PINIA_STATE_KEY) ||
+      sessionStorage.getItem(PINIA_STATE_KEY)
+    const parsed = raw ? JSON.parse(raw) : {}
+    const saved = parsed?.staySignedIn
+
+    return saved ? localStorage : sessionStorage
+  } catch (e) {
+    console.warn('Pinia storage fallback to sessionStorage due to error:', e)
+    return sessionStorage
+  }
+}
+
+export function setPiniaStorage(staySignedIn) {
+  try {
+    const storage = staySignedIn ? localStorage : sessionStorage
+
+    removeStorageFlagForPinia()
+
+    storage.setItem(
+      PINIA_STATE_KEY,
+      JSON.stringify({ staySignedIn: staySignedIn }),
+    )
+  } catch (e) {
+    console.error('Failed to set Pinia storage:', e)
+  }
+}
+
+export function removeStorageFlagForPinia() {
+  localStorage.removeItem(PINIA_STATE_KEY)
+  sessionStorage.removeItem(PINIA_STATE_KEY)
+}

--- a/front/src/shared/utils/piniaUtils.js
+++ b/front/src/shared/utils/piniaUtils.js
@@ -1,32 +1,16 @@
-const PINIA_STATE_KEY = 'pinia-state'
+import { useAuthStore } from '@/stores/useAuthStore'
+import { useDatePickStore } from '@/stores/useDatePickStore'
+import { useScheduleStore } from '@/stores/useScheduleStore'
+import { useUserInfoStore } from '@/stores/useUserInfoStore'
 
-export function getPiniaStorage() {
-  try {
-    const raw =
-      localStorage.getItem(PINIA_STATE_KEY) ||
-      sessionStorage.getItem(PINIA_STATE_KEY)
-    const parsed = raw ? JSON.parse(raw) : {}
-    const saved = parsed?.staySignedIn
+export const resetAllStores = () => {
+  const authStore = useAuthStore()
+  const datePickStore = useDatePickStore()
+  const scheduleStore = useScheduleStore()
+  const userInfoStore = useUserInfoStore()
 
-    return saved ? localStorage : sessionStorage
-  } catch (e) {
-    console.warn('Pinia storage fallback to sessionStorage due to error:', e)
-    return sessionStorage
-  }
-}
-
-export function setPiniaStorage(staySignedIn) {
-  try {
-    const storage = staySignedIn ? localStorage : sessionStorage
-
-    localStorage.removeItem(PINIA_STATE_KEY)
-    sessionStorage.removeItem(PINIA_STATE_KEY)
-
-    storage.setItem(
-      PINIA_STATE_KEY,
-      JSON.stringify({ staySignedIn: staySignedIn }),
-    )
-  } catch (e) {
-    console.error('Failed to set Pinia storage:', e)
-  }
+  authStore.reset()
+  datePickStore.reset()
+  scheduleStore.reset()
+  userInfoStore.reset()
 }

--- a/front/src/stores/useAuthStore.js
+++ b/front/src/stores/useAuthStore.js
@@ -1,4 +1,4 @@
-import { getPiniaStorage } from '@/shared/utils/piniaUtils'
+import { getPiniaStorage } from '@/shared/utils/piniaPersistUtils'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
@@ -20,6 +20,10 @@ export const useAuthStore = defineStore(
     const getToken = () => {
       return token.value
     }
+    const reset = () => {
+      staySignedIn.value = false
+      token.value = ''
+    }
 
     return {
       token,
@@ -27,6 +31,7 @@ export const useAuthStore = defineStore(
       setToken,
       setStaySignedIn,
       getToken,
+      reset,
     }
   },
   {

--- a/front/src/stores/useDatePickStore.js
+++ b/front/src/stores/useDatePickStore.js
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { format, startOfWeek } from 'date-fns'
 import { computed, ref } from 'vue'
-import { getPiniaStorage } from '@/shared/utils/piniaUtils'
+import { getPiniaStorage } from '@/shared/utils/piniaPersistUtils'
 
 export const useDatePickStore = defineStore(
   'date-pick',
@@ -32,6 +32,12 @@ export const useDatePickStore = defineStore(
       return selectedDate.value ?? format(new Date(), 'yyyy-MM-dd')
     })
 
+    const reset = () => {
+      weeklySelected.value = {}
+      monthlySelected.value = []
+      selectedDate.value = null
+    }
+
     return {
       // state
       weeklySelected,
@@ -44,6 +50,9 @@ export const useDatePickStore = defineStore(
 
       // getters
       lastSelectedDate,
+
+      // reset
+      reset,
     }
   },
   {

--- a/front/src/stores/useDatePickStore.js
+++ b/front/src/stores/useDatePickStore.js
@@ -34,7 +34,7 @@ export const useDatePickStore = defineStore(
 
     const reset = () => {
       weeklySelected.value = {}
-      monthlySelected.value = []
+      monthlySelected.value = {}
       selectedDate.value = null
     }
 

--- a/front/src/stores/useScheduleStore.js
+++ b/front/src/stores/useScheduleStore.js
@@ -109,8 +109,8 @@ export const useScheduleStore = defineStore(
     }
 
     const reset = () => {
-      dailySchedules.values = {}
-      rawSchedules.values = {}
+      for (const k in dailySchedules) delete dailySchedules[k]
+      for (const k in rawSchedules) delete rawSchedules[k]
     }
 
     return {

--- a/front/src/stores/useScheduleStore.js
+++ b/front/src/stores/useScheduleStore.js
@@ -5,7 +5,7 @@ import {
   buildRRuleString,
   expandSchedulesByDay,
 } from '@/shared/utils/rruleUtils'
-import { getPiniaStorage } from '@/shared/utils/piniaUtils'
+import { getPiniaStorage } from '@/shared/utils/piniaPersistUtils'
 
 export const useScheduleStore = defineStore(
   'schedule',
@@ -108,6 +108,11 @@ export const useScheduleStore = defineStore(
       }
     }
 
+    const reset = () => {
+      dailySchedules.values = {}
+      rawSchedules.values = {}
+    }
+
     return {
       setMonthlySchedules,
       addRawSchedule,
@@ -116,6 +121,7 @@ export const useScheduleStore = defineStore(
       getSchedulesForDate,
       getScheduleInstanceByKey,
       recalculateMonth,
+      reset,
     }
   },
   {

--- a/front/src/stores/useUserInfoStore.js
+++ b/front/src/stores/useUserInfoStore.js
@@ -1,6 +1,6 @@
-import { getPiniaStorage } from '@/shared/utils/piniaUtils'
-import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import { getPiniaStorage } from '@/shared/utils/piniaPersistUtils'
 
 export const useUserInfoStore = defineStore(
   'userInfo',
@@ -78,6 +78,20 @@ export const useUserInfoStore = defineStore(
           : briefingNotiEnabled.value
     }
 
+    const reset = () => {
+      id.value = null
+      email.value = ''
+      nickname.value = ''
+      healthStatusKeywords.value = []
+      profileKeywords.value = []
+      communicationTone.value = []
+      startOfDayTime.value = ''
+      endOfDayTime.value = ''
+      scheduleNotiEnabled.value = false
+      routineNotiEnabled.value = false
+      briefingNotiEnabled.value = false
+    }
+
     return {
       id,
       email,
@@ -92,6 +106,7 @@ export const useUserInfoStore = defineStore(
       briefingNotiEnabled,
       setUserInfo,
       setUserInfoWithDefaults,
+      reset,
     }
   },
   {


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #216 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
 
- **to-be**(변경 후 설명을 여기에 작성)
  - [ ] 회원 탈퇴시 피니아 전체 초기화
 

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 계정 탈퇴 완료 시 모든 앱 데이터 초기화 후 로그인 화면으로 이동해 더 깨끗한 종료 경험을 제공합니다.
- 버그 수정
  - 탈퇴/로그아웃 이후 세션, 일정, 사용자 정보 등이 간헐적으로 남던 문제를 해소했습니다.
- 리팩터
  - 주요 스토어에 reset 기능을 도입해 상태 초기화를 일관되게 수행하도록 개선했습니다.
  - 상태 관리 유틸리티를 단일화하여 초기화 흐름을 간소화했습니다.
- 기타
  - 불필요한 콘솔 로그를 제거해 노이즈를 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->