### PR TITLE
[#226][fe][schedule] 일정 조회  및 생성 후 재조회 로직 수정

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1149,9 +1149,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2836,14 +2836,14 @@
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.5.0.tgz",
-      "integrity": "sha512-wV7z0eUpifKmvmN78UBZX8T7lMW53Nrk6JP5+6hbzrB9+cJ3jr//hUlhl9TZO/03bUkMK6gGkQpqOPWoabr72g==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
+      "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
       "license": "MIT",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
-        "@vueuse/metadata": "13.5.0",
-        "@vueuse/shared": "13.5.0"
+        "@vueuse/metadata": "13.9.0",
+        "@vueuse/shared": "13.9.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2853,18 +2853,18 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.5.0.tgz",
-      "integrity": "sha512-euhItU3b0SqXxSy8u1XHxUCdQ8M++bsRs+TYhOLDU/OykS7KvJnyIFfep0XM5WjIFry9uAPlVSjmVHiqeshmkw==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
+      "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.5.0.tgz",
-      "integrity": "sha512-K7GrQIxJ/ANtucxIXbQlUHdB0TPA8c+q5i+zbrjxuhJCnJ9GtBg75sBSnvmLSxHKPg2Yo8w62PWksl9kwH0Q8g==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
+      "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -2914,9 +2914,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5402,9 +5402,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/front/src/features/auth/authService.js
+++ b/front/src/features/auth/authService.js
@@ -17,10 +17,10 @@ import {
   toVerifyPasswordCodePayload,
 } from './dto.js'
 import { useUserInfoStore } from '@/stores/useUserInfoStore.js'
-import { setPiniaStorage } from '@/shared/utils/piniaUtils.js'
 import { useAuthStore } from '@/stores/useAuthStore.js'
 import { registerUserDevice } from '../user/userService.js'
 import { requestPermissionAndInitFCM } from '@/shared/utils/notificationUtils.js'
+import { setPiniaStorage } from '@/shared/utils/piniaPersistUtils.js'
 
 export const requestEmailVerification = wrapApi(
   (email) => requestEmailVerificationApi(toEmailVerificationPayload(email)),

--- a/front/src/features/schedule/useScheduleForm.js
+++ b/front/src/features/schedule/useScheduleForm.js
@@ -126,10 +126,10 @@ export const useScheduleForm = (initValues = {}) => {
       const endDate = new Date(form.end)
 
       if (!newVal && isMidnight(endDate)) {
-        form.end = formatDateTime(addDays(form.end, 1))
+        form.end = formatDateTime(addDays(endDate, 1))
       }
       if (newVal && isMidnight(endDate)) {
-        form.end = formatDateTime(subDays(form.end, 1))
+        form.end = formatDateTime(subDays(endDate, 1))
       }
     },
     { immediate: false },

--- a/front/src/features/schedule/useScheduleForm.js
+++ b/front/src/features/schedule/useScheduleForm.js
@@ -10,18 +10,20 @@ import { createSchedule } from './scheduleService'
 import { useScheduleStore } from '@/stores/useScheduleStore'
 import { useDatePickStore } from '@/stores/useDatePickStore'
 
-const { selectedDate, setSelectedDate } = useDatePickStore()
-const { addRawSchedule } = useScheduleStore()
-
 export const useScheduleForm = (initValues = {}) => {
+  const datePickStore = useDatePickStore()
+  const scheduleStore = useScheduleStore()
+
   const createInitialForm = () => {
     let baseDate = new Date()
 
     if (initValues.start) {
       baseDate = new Date(initValues.start)
-      setSelectedDate(baseDate)
-    } else if (selectedDate) {
-      const [year, month, day] = selectedDate.split('-').map(Number)
+      datePickStore.setSelectedDate(baseDate)
+    } else if (datePickStore.selectedDate) {
+      const [year, month, day] = datePickStore.selectedDate
+        .split('-')
+        .map(Number)
       baseDate = new Date(
         year,
         month - 1,
@@ -70,6 +72,19 @@ export const useScheduleForm = (initValues = {}) => {
     }
   }
 
+  const refetchSchedulesByPeriod = async () => {
+    scheduleStore.reset()
+
+    const monthRange = datePickStore.monthRange
+    await scheduleStore.loadMonthlySchedulesIfNeeded(
+      monthRange.rangeStart,
+      monthRange.rangeEnd,
+    )
+    schedulesForSelectedMonth.value = scheduleStore.getSchedulesMonthlyByDate(
+      selectedDate.value,
+    )
+  }
+
   const onSubmit = async (onSuccess, onError) => {
     if (isSubmitting.value) return
 
@@ -81,7 +96,7 @@ export const useScheduleForm = (initValues = {}) => {
     isSubmitting.value = true
     try {
       const schedule = await createSchedule(form)
-      addRawSchedule(schedule)
+      refetchSchedulesByPeriod()
 
       await nextTick()
       onSuccess?.(schedule.id)

--- a/front/src/features/schedule/useScheduleForm.js
+++ b/front/src/features/schedule/useScheduleForm.js
@@ -80,9 +80,6 @@ export const useScheduleForm = (initValues = {}) => {
       monthRange.rangeStart,
       monthRange.rangeEnd,
     )
-    schedulesForSelectedMonth.value = scheduleStore.getSchedulesMonthlyByDate(
-      selectedDate.value,
-    )
   }
 
   const onSubmit = async (onSuccess, onError) => {
@@ -96,8 +93,7 @@ export const useScheduleForm = (initValues = {}) => {
     isSubmitting.value = true
     try {
       const schedule = await createSchedule(form)
-      refetchSchedulesByPeriod()
-
+      await refetchSchedulesByPeriod()
       await nextTick()
       onSuccess?.(schedule.id)
       return schedule.id

--- a/front/src/features/schedule/useScheduleList.js
+++ b/front/src/features/schedule/useScheduleList.js
@@ -87,9 +87,10 @@ export const useScheduleList = (maybeSelectedDate = null) => {
       if (!s || !n || isSameDay(s, os)) return
 
       const t = ++token
+      await fetchSchedulesByPeriod(s, n)
+
       if (t !== token) return // 최신 호출만 반영
 
-      await fetchSchedulesByPeriod(s, n)
       schedulesForSelectedMonth.value = scheduleStore.getSchedulesMonthlyByDate(
         selectedDate.value,
       )

--- a/front/src/features/schedule/useScheduleList.js
+++ b/front/src/features/schedule/useScheduleList.js
@@ -1,30 +1,20 @@
 import { ref, reactive, computed, watch, isRef } from 'vue'
 import { useRouter } from 'vue-router'
-import { debounce } from 'lodash-es'
-import { format, differenceInCalendarDays, subDays } from 'date-fns'
+import { format, differenceInCalendarDays, subDays, isSameDay } from 'date-fns'
 
 import { useScheduleStore } from '@/stores/useScheduleStore'
-import { getMonthRange } from '@/shared/utils/dateUtils'
-import { getSchedules } from './scheduleService'
+import { useDatePickStore } from '@/stores/useDatePickStore'
 
 export const useScheduleList = (maybeSelectedDate = null) => {
+  const scheduleStore = useScheduleStore()
+  const datePickStore = useDatePickStore()
+
   const selectedDate =
     maybeSelectedDate && isRef(maybeSelectedDate)
       ? maybeSelectedDate
       : ref(maybeSelectedDate ?? null)
 
   const errorModal = reactive({})
-
-  const router = useRouter()
-  const scheduleStore = useScheduleStore()
-
-  const weekRange = computed(() => {
-    if (!selectedDate.value) return { rangeStart: null, rangeEnd: null }
-    return getMonthRange(selectedDate.value)
-  })
-
-  const startOfThisMonth = computed(() => weekRange.value.rangeStart)
-  const startOfNextMonth = computed(() => weekRange.value.rangeEnd)
 
   const schedulesForSelectedDate = computed(() =>
     selectedDate.value
@@ -36,30 +26,10 @@ export const useScheduleList = (maybeSelectedDate = null) => {
     scheduleStore.getSchedulesMonthlyByDate(selectedDate.value),
   )
 
-  let debounceTimer = null
-  const fetchSchedulesByPeriod = async (fromAt, toAt) => {
-    if (scheduleStore.getSchedulesMonthlyByDate(fromAt)) {
-      return Promise.resolve()
-    }
+  const startOfThisMonth = computed(() => datePickStore.monthRange.rangeStart)
+  const startOfNextMonth = computed(() => datePickStore.monthRange.rangeEnd)
 
-    if (debounceTimer) clearTimeout(debounceTimer)
-
-    return new Promise((resolve, reject) => {
-      debounceTimer = setTimeout(async () => {
-        try {
-          const { data } = await getSchedules(fromAt, toAt)
-          const key = format(fromAt, 'yyyy-MM')
-          scheduleStore.setMonthlySchedules(key, data?.schedules)
-          resolve()
-        } catch (err) {
-          console.error(err)
-          errorModal.show = true
-          errorModal.msg = err.message || '스케줄 조회 실패'
-          reject(err)
-        }
-      }, 300)
-    })
-  }
+  const router = useRouter()
 
   const goToScheduleDetail = (schedule) => {
     if (!schedule?.id || !schedule?.instanceDate) return
@@ -100,14 +70,29 @@ export const useScheduleList = (maybeSelectedDate = null) => {
     return `${formattedStart} ~ ${formattedEnd}`
   }
 
+  const fetchSchedulesByPeriod = async (rangeStart, rangeEnd) => {
+    try {
+      await scheduleStore.loadMonthlySchedulesIfNeeded(rangeStart, rangeEnd)
+    } catch (err) {
+      console.error(err)
+      errorModal.show = true
+      errorModal.msg = err?.message || '스케줄 조회 실패'
+    }
+  }
+
+  let token = 0
   watch(
     [startOfThisMonth, startOfNextMonth],
-    async ([s, n]) => {
-      if (s && n) {
-        await fetchSchedulesByPeriod(s, n)
-        schedulesForSelectedMonth.value =
-          scheduleStore.getSchedulesMonthlyByDate(selectedDate.value)
-      }
+    async ([s, n], [os, on]) => {
+      if (!s || !n || isSameDay(s, os)) return
+
+      const t = ++token
+      if (t !== token) return // 최신 호출만 반영
+
+      await fetchSchedulesByPeriod(s, n)
+      schedulesForSelectedMonth.value = scheduleStore.getSchedulesMonthlyByDate(
+        selectedDate.value,
+      )
     },
     { immediate: true },
   )

--- a/front/src/shared/utils/rruleUtils.js
+++ b/front/src/shared/utils/rruleUtils.js
@@ -136,7 +136,7 @@ function expandRecurringSchedule(schedule, monthKey) {
 
 const compareSchedule = (a, b) => {
   // 1) 여러날 일정 우선
-  if (a.isContinued !== b.isContinued) return aCont ? -1 : 1
+  if (a.isContinued !== b.isContinued) return a.isContinued ? -1 : 1
 
   // 2) 하루종일(>=24h) 우선
   const aAll = isAllDay(a.startAt, a.endAt)
@@ -144,9 +144,9 @@ const compareSchedule = (a, b) => {
   if (aAll !== bAll) return aAll ? -1 : 1
 
   // 3) 시작시간 오름차순
-  const as = new Date(a.startDate)
-  const bs = new Date(b.startDate)
-  if (a.startDate && b.startDate) {
+  const as = new Date(a.startAt)
+  const bs = new Date(b.startAt)
+  if (as && bs) {
     if (isBefore(as, bs)) return -1
     if (isBefore(bs, as)) return 1
   } else if (as || bs) {
@@ -155,8 +155,8 @@ const compareSchedule = (a, b) => {
   }
 
   // 4) 동률이면 종료시간 → 제목 → id로 안정적 타이브레이크
-  const ae = new Date(a.endDate)
-  const be = new Date(b.endDate)
+  const ae = new Date(a.endAt)
+  const be = new Date(b.endAt)
   if (ae && be) {
     if (isBefore(ae, be)) return -1
     if (isBefore(be, ae)) return 1

--- a/front/src/shared/utils/rruleUtils.js
+++ b/front/src/shared/utils/rruleUtils.js
@@ -7,7 +7,9 @@ import {
   isAfter,
   isSameDay,
   startOfDay,
+  isBefore,
 } from 'date-fns'
+import { isAllDay } from './dateUtils'
 
 function getMonthRange(monthKey) {
   const base = new Date(`${monthKey}-01`)
@@ -27,14 +29,13 @@ function createIcalComponent(rruleStr, dtstart) {
   return event
 }
 
-function expandMultiDaySchedule(base, start, end, rangeEnd) {
+function expandMultiDaySchedule(base, start, end, rangeStart, rangeEnd) {
   const result = []
 
-  for (
-    let d = startOfDay(new Date(start));
-    d < end;
-    d.setDate(d.getDate() + 1)
-  ) {
+  let startDate = new Date(start)
+  if (isBefore(startDate, rangeStart)) startDate = rangeStart
+
+  for (let d = startOfDay(startDate); d < end; d.setDate(d.getDate() + 1)) {
     const dCopy = new Date(d)
     if (isAfter(dCopy, rangeEnd)) break
 
@@ -51,22 +52,14 @@ function expandMultiDaySchedule(base, start, end, rangeEnd) {
   return result
 }
 
-export function expandRecurringSchedule(schedule, monthKey) {
+function expandRecurringSchedule(schedule, monthKey) {
   const recurrence = schedule.recurrenceRule
   const startDate = parseISO(schedule.startAt)
   const endDate = parseISO(schedule.endAt)
   const durationMs = endDate.getTime() - startDate.getTime()
   const { rangeStart, rangeEnd } = getMonthRange(monthKey)
 
-  const overrideMap = new Map(
-    (schedule.scheduleOverrides || []).map((o) => [
-      format(parseISO(o.overrideDate), 'yyyy-MM-dd'),
-      o,
-    ]),
-  )
-
-  const result = []
-
+  // 반복이 없는 경우
   if (!recurrence || !recurrence.rruleStr) {
     return expandMultiDaySchedule(
       {
@@ -75,59 +68,106 @@ export function expandRecurringSchedule(schedule, monthKey) {
       },
       startDate,
       endDate,
+      rangeStart,
       rangeEnd,
     )
   }
+
+  // 반복이 있는 경우
+  const overrideDates = new Set(
+    (schedule.scheduleOverrides || []).map((o) =>
+      format(parseISO(o.overrideDate), 'yyyy-MM-dd'),
+    ),
+  )
 
   const event = createIcalComponent(
     recurrence.rruleStr,
     recurrence.dtstart || schedule.startAt,
   )
-  const iterator = event.iterator()
+  const iterator = event.iterator(ICAL.Time.fromJSDate(rangeStart, false))
 
+  const result = []
   let next
   while ((next = iterator.next())) {
     const nextDate = next.toJSDate()
     if (nextDate > rangeEnd) break
-    if (nextDate < rangeStart) continue
 
     const dateKey = format(nextDate, 'yyyy-MM-dd')
 
-    if (overrideMap.has(dateKey)) {
-      const override = overrideMap.get(dateKey)
-      const oStart = parseISO(override.startAt)
-      const oEnd = parseISO(override.endAt)
+    if (overrideDates.has(dateKey)) continue // 오버라이드는 아래 따로 추가
 
-      result.push(
-        ...expandMultiDaySchedule(
-          {
-            ...override,
-            originId: schedule.id,
-          },
-          oStart,
-          oEnd,
-          rangeEnd,
-        ),
-      )
-    } else {
-      const start = new Date(nextDate)
-      const end = new Date(start.getTime() + durationMs)
+    const start = new Date(nextDate)
+    const end = new Date(start.getTime() + durationMs)
 
-      result.push(
-        ...expandMultiDaySchedule(
-          {
-            ...schedule,
-            originId: schedule.id,
-          },
-          start,
-          end,
-          rangeEnd,
-        ),
-      )
-    }
+    result.push(
+      ...expandMultiDaySchedule(
+        {
+          ...schedule,
+          originId: schedule.id,
+        },
+        start,
+        end,
+        rangeStart,
+        rangeEnd,
+      ),
+    )
   }
 
+  // 오버라이드 된 일정 추가
+  for (const override of schedule.scheduleOverrides || []) {
+    const oStart = parseISO(override.startAt)
+    const oEnd = parseISO(override.endAt)
+
+    result.push(
+      ...expandMultiDaySchedule(
+        {
+          ...override,
+          originId: schedule.id,
+        },
+        oStart,
+        oEnd,
+        rangeStart,
+        rangeEnd,
+      ),
+    )
+  }
   return result
+}
+
+const compareSchedule = (a, b) => {
+  // 1) 여러날 일정 우선
+  if (a.isContinued !== b.isContinued) return aCont ? -1 : 1
+
+  // 2) 하루종일(>=24h) 우선
+  const aAll = isAllDay(a.startAt, a.endAt)
+  const bAll = isAllDay(b.startAt, b.endAt)
+  if (aAll !== bAll) return aAll ? -1 : 1
+
+  // 3) 시작시간 오름차순
+  const as = new Date(a.startDate)
+  const bs = new Date(b.startDate)
+  if (a.startDate && b.startDate) {
+    if (isBefore(as, bs)) return -1
+    if (isBefore(bs, as)) return 1
+  } else if (as || bs) {
+    // 시작시간 없는 건 뒤로
+    return as ? -1 : 1
+  }
+
+  // 4) 동률이면 종료시간 → 제목 → id로 안정적 타이브레이크
+  const ae = new Date(a.endDate)
+  const be = new Date(b.endDate)
+  if (ae && be) {
+    if (isBefore(ae, be)) return -1
+    if (isBefore(be, ae)) return 1
+  } else if (ae || be) {
+    return ae ? -1 : 1
+  }
+
+  return (
+    String(a.title ?? '').localeCompare(String(b.title ?? '')) ||
+    String(a.id ?? '').localeCompare(String(b.id ?? ''))
+  )
 }
 
 export function expandSchedulesByDay(schedules, monthKey) {
@@ -139,7 +179,7 @@ export function expandSchedulesByDay(schedules, monthKey) {
 
     const instances = expandRecurringSchedule(schedule, monthKey)
 
-    instances.forEach((instance) => {
+    instances.sort(compareSchedule).forEach((instance) => {
       const dateKey = instance.instanceDate
       const instanceKey = `${instance.id}@${dateKey}`
 

--- a/front/src/stores/useAuthStore.js
+++ b/front/src/stores/useAuthStore.js
@@ -26,8 +26,9 @@ export const useAuthStore = defineStore(
     }
 
     return {
-      token,
       staySignedIn,
+      token,
+
       setToken,
       setStaySignedIn,
       getToken,

--- a/front/src/stores/useDatePickStore.js
+++ b/front/src/stores/useDatePickStore.js
@@ -14,7 +14,7 @@ export const useDatePickStore = defineStore(
 
     const monthRange = computed(() => {
       if (!selectedDate.value) return { rangeStart: null, rangeEnd: null }
-      return getMonthRange(selectedDate.value)
+      return getMonthRange(new Date(selectedDate.value))
     })
 
     function getSelectedDate(baseDate, isMonthly = false) {

--- a/front/src/stores/useDatePickStore.js
+++ b/front/src/stores/useDatePickStore.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { format, startOfWeek } from 'date-fns'
 import { computed, ref } from 'vue'
 import { getPiniaStorage } from '@/shared/utils/piniaPersistUtils'
+import { getMonthRange } from '@/shared/utils/dateUtils'
 
 export const useDatePickStore = defineStore(
   'date-pick',
@@ -10,6 +11,11 @@ export const useDatePickStore = defineStore(
     const weeklySelected = ref({}) // key: '2024-07-14', value: '2024-07-17'
     const monthlySelected = ref({}) // key: '2024-07', value: '2024-07-01'
     const selectedDate = ref(null)
+
+    const monthRange = computed(() => {
+      if (!selectedDate.value) return { rangeStart: null, rangeEnd: null }
+      return getMonthRange(selectedDate.value)
+    })
 
     function getSelectedDate(baseDate, isMonthly = false) {
       const key = isMonthly
@@ -43,10 +49,12 @@ export const useDatePickStore = defineStore(
       weeklySelected,
       monthlySelected,
       selectedDate,
+      monthRange,
 
       // actions
       getSelectedDate,
       setSelectedDate,
+      getMonthRange,
 
       // getters
       lastSelectedDate,

--- a/front/src/stores/useScheduleStore.js
+++ b/front/src/stores/useScheduleStore.js
@@ -1,11 +1,9 @@
-import { reactive } from 'vue'
+import { reactive, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { format } from 'date-fns'
-import {
-  buildRRuleString,
-  expandSchedulesByDay,
-} from '@/shared/utils/rruleUtils'
+import { expandSchedulesByDay } from '@/shared/utils/rruleUtils'
 import { getPiniaStorage } from '@/shared/utils/piniaPersistUtils'
+import { getSchedules } from '@/features/schedule/scheduleService'
 
 export const useScheduleStore = defineStore(
   'schedule',
@@ -23,10 +21,10 @@ export const useScheduleStore = defineStore(
      *   ...
      * }
      */
-    const dailySchedules = reactive({})
+    const dailySchedules = ref({})
 
     // 서버 응답 원본 저장: 재계산이 필요할 때 활용
-    const rawSchedules = reactive({}) // { '2025-07': [schedule, ...] }
+    const rawSchedules = ref({}) // { '2025-07': [schedule, ...] }
 
     /**
      * 월 단위로 기존 데이터 제거 후 새로 채움
@@ -35,41 +33,23 @@ export const useScheduleStore = defineStore(
       if (!Array.isArray(schedules)) return
 
       const { dailyMap, rawMap } = expandSchedulesByDay(schedules, monthKey)
-      rawSchedules[monthKey] = rawMap
-      dailySchedules[monthKey] = dailyMap
-    }
 
-    const addRawSchedule = (schedule) => {
-      if (!schedule || !schedule.startAt || !schedule.id) return
-
-      const date = new Date(schedule.startAt)
-      const monthKey = format(date, 'yyyy-MM')
-
-      if (schedule.recurrenceRule) {
-        schedule.recurrenceRule.rruleStr = buildRRuleString(
-          schedule.recurrenceRule,
-        )
-      }
-
-      if (!rawSchedules[monthKey]) {
-        rawSchedules[monthKey] = {}
-      }
-      rawSchedules[monthKey][schedule.id] = schedule
-
-      recalculateMonth(monthKey)
+      rawSchedules.value[monthKey] = rawMap
+      dailySchedules.value[monthKey] = dailyMap
     }
 
     /**
      * 월간 키 존재 여부 확인 (중복 조회 방지 등)
      */
-    const hasMonth = (monthKey) => !!dailySchedules[monthKey]
+    const hasMonth = (monthKey) => !!dailySchedules.value[monthKey]
 
     /**
      * 해당 월 전체 일정 리스트 반환 (flat)
      */
     const getSchedulesMonthlyByDate = (date) => {
       const monthKey = format(date, 'yyyy-MM')
-      const monthData = dailySchedules[monthKey]
+      const monthData = dailySchedules.value[monthKey]
+
       if (!monthData) return null
 
       return Object.values(monthData).flatMap((instances) =>
@@ -84,7 +64,7 @@ export const useScheduleStore = defineStore(
       const dateKey = format(date, 'yyyy-MM-dd')
       const monthKey = dateKey.slice(0, 7)
 
-      return Object.values(dailySchedules[monthKey]?.[dateKey] || {})
+      return Object.values(dailySchedules.value[monthKey]?.[dateKey] || {})
     }
 
     /**
@@ -95,33 +75,68 @@ export const useScheduleStore = defineStore(
       const [, dateKey] = instanceKey.split('@')
       const monthKey = dateKey.slice(0, 7)
 
-      return dailySchedules?.[monthKey]?.[dateKey]?.[instanceKey] || null
+      return dailySchedules.value?.[monthKey]?.[dateKey]?.[instanceKey] || null
     }
 
     /**
      * (선택) 원본 스케줄 기준으로 다시 확장 계산
      */
     const recalculateMonth = (monthKey) => {
-      const base = rawSchedules[monthKey]
+      const base = rawSchedules.value[monthKey]
       if (base) {
         setMonthlySchedules(monthKey, Object.values(base))
       }
     }
 
     const reset = () => {
-      for (const k in dailySchedules) delete dailySchedules[k]
-      for (const k in rawSchedules) delete rawSchedules[k]
+      dailySchedules.value = {}
+      rawSchedules.value = {}
+    }
+
+    // ↓↓↓ 공통 로더: 디바운스 + 중복요청 방지 (키별)
+    const _timers = new Map() // monthKey -> timeout id
+    const _inflight = new Map() // monthKey -> Promise
+
+    async function loadMonthlySchedulesIfNeeded(fromAt, toAt, delay = 300) {
+      const monthKey = format(fromAt, 'yyyy-MM')
+
+      if (hasMonth(monthKey)) return // 캐시 히트
+
+      if (_inflight.has(monthKey)) return _inflight.get(monthKey) // 진행중이면 재활용
+
+      clearTimeout(_timers.get(monthKey))
+
+      const p = new Promise((resolve, reject) => {
+        const id = setTimeout(async () => {
+          _timers.delete(monthKey)
+          try {
+            const { data } = await getSchedules(fromAt, toAt)
+            setMonthlySchedules(monthKey, data?.schedules)
+            resolve()
+          } catch (e) {
+            reject(e)
+          } finally {
+            _inflight.delete(monthKey)
+          }
+        }, delay)
+        _timers.set(monthKey, id)
+      })
+
+      _inflight.set(monthKey, p)
+      return p
     }
 
     return {
+      rawSchedules,
+      dailySchedules,
       setMonthlySchedules,
-      addRawSchedule,
       hasMonth,
       getSchedulesMonthlyByDate,
       getSchedulesForDate,
       getScheduleInstanceByKey,
       recalculateMonth,
       reset,
+      loadMonthlySchedulesIfNeeded,
     }
   },
   {

--- a/front/src/stores/useScheduleStore.js
+++ b/front/src/stores/useScheduleStore.js
@@ -103,15 +103,15 @@ export const useScheduleStore = defineStore(
       if (hasMonth(monthKey)) return // 캐시 히트
 
       if (_inflight.has(monthKey)) return _inflight.get(monthKey) // 진행중이면 재활용
-
       clearTimeout(_timers.get(monthKey))
 
       const p = new Promise((resolve, reject) => {
         const id = setTimeout(async () => {
           _timers.delete(monthKey)
+
           try {
             const { data } = await getSchedules(fromAt, toAt)
-            setMonthlySchedules(monthKey, data?.schedules)
+            setMonthlySchedules(monthKey, data?.schedules || [])
             resolve()
           } catch (e) {
             reject(e)


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #226 

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - rrule 파싱 로직에서 범위를 벗어나는 오버라이드 일정 제외되는 오류 발견
  - 일정 생성 후 피니아만 수정했으나 문제 발견하여 로직 변경

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 조회 로직(rrule 파싱 외) 보완
  - [x] 일정 생성 후 재조회하도록 로직 수정

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 선택한 달 범위에 맞춰 일정이 자동 로딩/갱신됩니다.
  - 일정 생성 후 현재 기간의 월간 일정이 즉시 새로고침됩니다.
  - 반복/여러 일자 일정이 기간 기준으로 확장되며, 예외(오버라이드)를 정확히 반영합니다.
  - 일정 목록 정렬이 안정적으로 개선되어(종일/다일정 우선 등) 표시 일관성이 향상됩니다.

- 리팩터
  - 월 범위 계산을 공용 스토어로 통합하여 데이터 흐름을 단순화했습니다.
  - 불필요한 중복 요청을 줄이는 지연·중복 방지 로더를 도입했습니다.
  - 오류 발생 시 에러 모달 표시 처리를 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->