### PR TITLE
[#210][be][assistant] 배치 알림 이벤트 url수정

### DIFF
--- a/back/src/main/java/com/rouby/batch/job/briefing/step/BriefingProcessor.java
+++ b/back/src/main/java/com/rouby/batch/job/briefing/step/BriefingProcessor.java
@@ -12,6 +12,7 @@ import com.rouby.notification.notificationEvent.domain.entity.NotificationType;
 import com.rouby.notification.notificationtemplate.application.dto.query.NotificationMessageQuery;
 import com.rouby.notification.notificationtemplate.application.service.NotificationTemplateReadService;
 import com.rouby.notification.notificationtemplate.domain.entity.Message;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,7 @@ public class BriefingProcessor implements ItemProcessor<UserBriefingInfo, Briefi
         .deviceTokenInfos(deviceTokenInfos)
         .title(message.getTitle())
         .body(message.getBody())
+        .url("/briefing/daily/" + user.today().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
         .notificationType(NotificationType.BRIEFING)
         .build();
 

--- a/back/src/main/java/com/rouby/batch/job/briefing/step/BriefingProcessor.java
+++ b/back/src/main/java/com/rouby/batch/job/briefing/step/BriefingProcessor.java
@@ -25,6 +25,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class BriefingProcessor implements ItemProcessor<UserBriefingInfo, BriefingAggregate> {
 
+  private static final String BriefingUrlPrefix = "/briefing/daily/";
+
   private final BriefingFacade briefingFacade;
   private final NotificationTemplateReadService notificationTemplateReadService;
 
@@ -50,7 +52,7 @@ public class BriefingProcessor implements ItemProcessor<UserBriefingInfo, Briefi
         .deviceTokenInfos(deviceTokenInfos)
         .title(message.getTitle())
         .body(message.getBody())
-        .url("/briefing/daily/" + user.today().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+        .url(BriefingUrlPrefix + user.today().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
         .notificationType(NotificationType.BRIEFING)
         .build();
 

--- a/back/src/main/java/com/rouby/batch/job/briefing/step/BriefingWriter.java
+++ b/back/src/main/java/com/rouby/batch/job/briefing/step/BriefingWriter.java
@@ -5,8 +5,8 @@ import com.rouby.assistant.briefing.domain.repository.BriefingRepository;
 import com.rouby.batch.job.briefing.dto.BriefingAggregate;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
 import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
@@ -28,21 +28,11 @@ public class BriefingWriter implements ItemWriter<BriefingAggregate> {
         .toList();
     List<Briefing> savedBriefings = briefingRepository.saveAll(briefings);
 
-    List<NotificationEvent> allEvents = new ArrayList<>();
-    for (int i = 0; i < chunk.size(); i++) {
-      BriefingAggregate agg = chunk.getItems().get(i);
-      Briefing saved = savedBriefings.get(i);
-
-      List<NotificationEvent> events = agg.notificationEvents() != null
-          ? agg.notificationEvents().toEntities() : List.of();
-
-      if (!events.isEmpty()) {
-        events.forEach(e -> e.updateMessageUrl("/briefing/daily/" + saved.getId()));
-      }
-      allEvents.addAll(events);
-
-      log.info("Prepared briefing {} with {} notifications", saved.getId(), events.size());
-    }
+    List<NotificationEvent> allEvents = chunk.getItems().stream()
+        .flatMap(agg -> agg.notificationEvents() != null
+            ? agg.notificationEvents().toEntities().stream()
+            : Stream.empty())
+        .toList();
 
     if (!allEvents.isEmpty()) {
       notificationEventRepository.saveAll(allEvents);


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #210 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
reader에서 브리핑 id로 알림이벤트생성

- **to-be**
  - [x]processor에서 url설정 후  reader에서 그냥 저장
  - 
## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 일일 브리핑 알림에 날짜 기반 링크가 추가되어, 알림에서 바로 해당 날짜 브리핑으로 이동할 수 있습니다.
* Refactor
  * 알림 이벤트를 한 번에 수집·저장하는 방식으로 배치 성능과 처리 일관성을 개선했습니다.
  * 불필요한 개별 처리/로그를 제거하고 배치 단위 요약 로그로 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->