### PR TITLE
[#13][be][schedule]feat: 일정 수정 api

### DIFF
--- a/back/src/docs/asciidoc/schedule.adoc
+++ b/back/src/docs/asciidoc/schedule.adoc
@@ -52,3 +52,29 @@ include::{snippets}/get-schedules-invalid-request-400/http-request.adoc[]
 include::{snippets}/get-schedules-invalid-request-400/http-response.adoc[]
 
 ---
+
+[[Update-Schedules]]
+== 일정 수정 API
+
+=== 성공: 일정 수정 요청
+
+==== HTTP 요청
+include::{snippets}/update-schedule-200/http-request.adoc[]
+
+==== 요청 필드
+include::{snippets}/update-schedule-200/request-fields.adoc[]
+
+==== HTTP 응답 (200 OK)
+include::{snippets}/update-schedule-200/http-response.adoc[]
+
+=== 실패: 유효성 검증 오류
+
+==== 알람 설정 시간 오류
+
+===== HTTP 요청
+include::{snippets}/update-schedule-invalid-alarm-offset-400/http-request.adoc[]
+
+===== HTTP 응답 (400 Bad Request)
+include::{snippets}/update-schedule-invalid-alarm-offset-400/http-response.adoc[]
+
+---

--- a/back/src/main/java/com/rouby/schedule/application/dto/command/UpdateScheduleCommand.java
+++ b/back/src/main/java/com/rouby/schedule/application/dto/command/UpdateScheduleCommand.java
@@ -1,0 +1,36 @@
+package com.rouby.schedule.application.dto.command;
+
+import com.rouby.schedule.domain.entity.Schedule;
+import com.rouby.schedule.domain.enums.OverrideType;
+import com.rouby.schedule.domain.vo.OverrideInfo;
+import com.rouby.schedule.domain.vo.Period;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record UpdateScheduleCommand(
+    Long parentScheduleId,
+    Long targetScheduleId,
+    String title,
+    String memo,
+    Integer alarmOffsetMinutes,
+    LocalDate overrideDate,
+    LocalDateTime startAt,
+    LocalDateTime endAt
+) {
+
+  public Schedule toEntityWithUserId(Long userId, Schedule parentSchedule) {
+    return Schedule.createByModify(
+        userId,
+        title,
+        memo,
+        Period.builder().startAt(startAt).endAt(endAt).build(),
+        alarmOffsetMinutes,
+        parentSchedule,
+        OverrideInfo.builder()
+            .overrideDate(overrideDate)
+            .overrideType(OverrideType.MODIFIED)
+            .build());
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/application/exception/ScheduleErrorCode.java
+++ b/back/src/main/java/com/rouby/schedule/application/exception/ScheduleErrorCode.java
@@ -13,6 +13,12 @@ public enum ScheduleErrorCode implements ErrorCode {
       "유효하지 않은 요청 정보입니다.",
       "SCHEDULE_INVALID_REQUEST",
       HttpStatus.UNPROCESSABLE_ENTITY),
+
+
+  SCHEDULE_NOT_FOUND(
+      "존재하지 않는 일정입니다.",
+          "SCHEDULE_NOT_FOUND",
+      HttpStatus.NOT_FOUND),
   ;
   private final String message;
   private final String code;

--- a/back/src/main/java/com/rouby/schedule/application/facade/ScheduleFacade.java
+++ b/back/src/main/java/com/rouby/schedule/application/facade/ScheduleFacade.java
@@ -1,6 +1,7 @@
 package com.rouby.schedule.application.facade;
 
 import com.rouby.schedule.application.dto.command.CreateScheduleCommand;
+import com.rouby.schedule.application.dto.command.UpdateScheduleCommand;
 import com.rouby.schedule.application.dto.info.SchedulesInfo;
 import com.rouby.schedule.application.dto.query.GetScheduleQuery;
 import com.rouby.schedule.application.service.ScheduleReadService;
@@ -21,5 +22,9 @@ public class ScheduleFacade {
 
   public SchedulesInfo getSchedules(GetScheduleQuery query) {
     return scheduleReadService.findSchedulesBy(query);
+  }
+
+  public Long updateSchedule(Long userId, UpdateScheduleCommand command) {
+    return scheduleWriteService.updateSchedule(userId, command);
   }
 }

--- a/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
+++ b/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
@@ -36,10 +36,20 @@ public class ScheduleWriteService {
 
   @Transactional
   public Long updateSchedule(Long userId, UpdateScheduleCommand command) {
-    Schedule schedule = null;
-    log.info("originId = target 분기 처리 전");
-    if (!Objects.equals(command.parentScheduleId(), command.targetScheduleId())) {
-      schedule = scheduleRepository.findById(command.targetScheduleId())
+
+    try {
+      final boolean createOverride = command.targetScheduleId() == null
+              || Objects.equals(command.parentScheduleId(), command.targetScheduleId());
+      if (createOverride) {
+        Schedule parent = scheduleRepository
+            .findByIdAndUserId(command.parentScheduleId(), userId)
+            .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+        Schedule newSchedule = command.toEntityWithUserId(userId, parent);
+        return scheduleRepository.save(newSchedule).getId();
+      }
+
+      Schedule schedule = scheduleRepository
+          .findByIdAndUserId(command.targetScheduleId(), userId)
           .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
 
       schedule.validateUpdatable();
@@ -47,16 +57,11 @@ public class ScheduleWriteService {
           .startAt(command.startAt())
           .endAt(command.endAt())
           .build();
-
       AlarmOffsetType alarmOffsetType = AlarmOffsetType.parse(command.alarmOffsetMinutes());
       schedule.update(command.title(), command.memo(), period, alarmOffsetType);
       return schedule.getId();
-    } else {
-      Schedule parentSchedule = scheduleRepository.findById(command.parentScheduleId())
-          .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
-      schedule = command.toEntityWithUserId(userId, parentSchedule);
-      Schedule savedSchedule = scheduleRepository.save(schedule);
-      return savedSchedule.getId();
+    } catch (IllegalArgumentException e) {
+      throw ScheduleException.of(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST, e.getMessage());
     }
   }
 }

--- a/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
+++ b/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
@@ -1,15 +1,23 @@
 package com.rouby.schedule.application.service;
 
+
 import com.rouby.schedule.application.dto.command.CreateScheduleCommand;
+import com.rouby.schedule.application.dto.command.UpdateScheduleCommand;
 import com.rouby.schedule.application.exception.ScheduleErrorCode;
 import com.rouby.schedule.application.exception.ScheduleException;
 import com.rouby.schedule.domain.entity.Schedule;
+import com.rouby.schedule.domain.enums.AlarmOffsetType;
 import com.rouby.schedule.domain.repository.ScheduleRepository;
+import com.rouby.schedule.domain.vo.Period;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class ScheduleWriteService {
 
   private final ScheduleRepository scheduleRepository;
@@ -23,6 +31,32 @@ public class ScheduleWriteService {
 
     } catch (IllegalArgumentException e) {
       throw ScheduleException.of(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST, e.getMessage());
+    }
+  }
+
+  @Transactional
+  public Long updateSchedule(Long userId, UpdateScheduleCommand command) {
+    Schedule schedule = null;
+    log.info("originId = target 분기 처리 전");
+    if (!Objects.equals(command.parentScheduleId(), command.targetScheduleId())) {
+      schedule = scheduleRepository.findById(command.targetScheduleId())
+          .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+
+      schedule.validateUpdatable();
+      Period period = Period.builder()
+          .startAt(command.startAt())
+          .endAt(command.endAt())
+          .build();
+
+      AlarmOffsetType alarmOffsetType = AlarmOffsetType.parse(command.alarmOffsetMinutes());
+      schedule.update(command.title(), command.memo(), period, alarmOffsetType);
+      return schedule.getId();
+    } else {
+      Schedule parentSchedule = scheduleRepository.findById(command.parentScheduleId())
+          .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+      schedule = command.toEntityWithUserId(userId, parentSchedule);
+      Schedule savedSchedule = scheduleRepository.save(schedule);
+      return savedSchedule.getId();
     }
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
@@ -74,18 +74,48 @@ public class Schedule extends BaseEntity {
   @Embedded
   private OverrideInfo overrideInfo;
 
+  public static Schedule createByModify(Long userId, String title, String memo, Period period,
+      Integer alarmOffsetMinutes, Schedule parentSchedule, OverrideInfo overrideInfo) {
+    return Schedule.builder()
+        .userId(userId)
+        .title(title)
+        .memo(memo)
+        .period(period)
+        .alarmOffsetMinutes(alarmOffsetMinutes)
+        .parentSchedule(parentSchedule)
+        .overrideInfo(overrideInfo)
+        .build();
+  }
+
+  public void validateUpdatable() {
+    if (overrideInfo.isCancelled()) {
+      throw new IllegalArgumentException("취소된 일정입니다.");
+    }
+  }
+
+  public void update(String title, String memo, Period period, AlarmOffsetType alarmOffsetType) {
+    this.title = title;
+    this.memo = memo;
+    this.period = period;
+    this.alarmOffsetType = alarmOffsetType;
+  }
+
   @Builder
   private Schedule(Long userId, String title, String memo, Period period,
-      Integer routineOffsetDays, Integer alarmOffsetMinutes, RecurrenceRule recurrenceRule) {
+      Integer routineOffsetDays, Integer alarmOffsetMinutes,
+      Schedule parentSchedule, OverrideInfo overrideInfo,
+      RecurrenceRule recurrenceRule) {
 
     this.userId = userId;
     this.title = title;
     this.memo = memo;
     this.period = period;
     this.routineOffsetDays = routineOffsetDays;
-    this.alarmOffsetType = alarmOffsetMinutes != null ? AlarmOffsetType.parse(alarmOffsetMinutes) : null;
+    this.alarmOffsetType =
+        alarmOffsetMinutes != null ? AlarmOffsetType.parse(alarmOffsetMinutes) : null;
+    this.parentSchedule = parentSchedule;
+    this.overrideInfo = overrideInfo;
     this.recurrenceRule = recurrenceRule;
-
     validate();
   }
 
@@ -108,12 +138,16 @@ public class Schedule extends BaseEntity {
   }
 
   private void addToParentSchedule() {
-    if (parentSchedule == null) return;
+    if (parentSchedule == null) {
+      return;
+    }
     this.parentSchedule.appendChildSchedule(this);
   }
 
   private void appendChildSchedule(Schedule schedule) {
-    if (this.children == null) this.children = new ArrayList<>();
+    if (this.children == null) {
+      this.children = new ArrayList<>();
+    }
     this.children.add(schedule);
   }
 

--- a/back/src/main/java/com/rouby/schedule/domain/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/rouby/schedule/domain/repository/ScheduleRepository.java
@@ -15,4 +15,6 @@ public interface ScheduleRepository {
   <S extends Schedule> Iterable<S> saveAll(Iterable<S> entities);
 
   Optional<Schedule> findById(Long id);
+
+  Optional<Schedule> findByIdAndUserId(Long id, Long userId);
 }

--- a/back/src/main/java/com/rouby/schedule/domain/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/rouby/schedule/domain/repository/ScheduleRepository.java
@@ -4,6 +4,7 @@ import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.repository.criteria.GetScheduleCriteria;
 import com.rouby.schedule.domain.repository.info.ScheduleWithOverrides;
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleRepository {
 
@@ -12,4 +13,6 @@ public interface ScheduleRepository {
   List<ScheduleWithOverrides> findSchedulesByCriteria(GetScheduleCriteria criteria);
 
   <S extends Schedule> Iterable<S> saveAll(Iterable<S> entities);
+
+  Optional<Schedule> findById(Long id);
 }

--- a/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
@@ -1,5 +1,7 @@
 package com.rouby.schedule.domain.vo;
 
+import static com.rouby.schedule.domain.enums.OverrideType.*;
+
 import com.rouby.schedule.domain.enums.OverrideType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
@@ -27,5 +29,9 @@ public class OverrideInfo {
 
     this.overrideType = overrideType;
     this.overrideDate = overrideDate;
+  }
+
+  public boolean isCancelled() {
+    return overrideType == CANCELLED;
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
@@ -1,6 +1,6 @@
 package com.rouby.schedule.domain.vo;
 
-import static com.rouby.schedule.domain.enums.OverrideType.*;
+import static com.rouby.schedule.domain.enums.OverrideType.CANCELLED;
 
 import com.rouby.schedule.domain.enums.OverrideType;
 import jakarta.persistence.Embeddable;

--- a/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepository.java
+++ b/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepository.java
@@ -2,6 +2,7 @@ package com.rouby.schedule.infrastructure.persistence.jpa;
 
 import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.repository.ScheduleRepository;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleJpaRepository extends

--- a/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
@@ -3,6 +3,7 @@ package com.rouby.schedule.presentation;
 import com.rouby.schedule.application.facade.ScheduleFacade;
 import com.rouby.schedule.presentation.dto.request.CreateScheduleRequest;
 import com.rouby.schedule.presentation.dto.request.GetScheduleRequest;
+import com.rouby.schedule.presentation.dto.request.UpdateScheduleRequest;
 import com.rouby.schedule.presentation.dto.response.SchedulesResponse;
 import com.rouby.user.user.infrastructure.security.dto.SecurityUser;
 import java.net.URI;
@@ -13,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,5 +50,14 @@ public class ScheduleController {
         SchedulesResponse.of(scheduleFacade.getSchedules(req.toQuery(securityUser.getId())));
 
     return ResponseEntity.ok().body(response);
+  }
+
+  @PreAuthorize("hasAnyRole('USER')")
+  @PutMapping
+  public ResponseEntity<Long> updateSchedule(
+      @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated UpdateScheduleRequest req) {
+
+    Long scheduleId = scheduleFacade.updateSchedule(securityUser.getId(), req.toCommand());
+    return ResponseEntity.ok().body(scheduleId);
   }
 }

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/request/UpdateScheduleRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/request/UpdateScheduleRequest.java
@@ -1,0 +1,35 @@
+package com.rouby.schedule.presentation.dto.request;
+
+import com.rouby.schedule.application.dto.command.UpdateScheduleCommand;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record UpdateScheduleRequest(
+    @NotNull Long parentScheduleId,
+    Long targetScheduleId,
+    @NotBlank @Size(max = 500) String title,
+    @Size(max = 10_000) String memo,
+    @PositiveOrZero @Max(10080) Integer alarmOffsetMinutes,
+    @NotNull LocalDate overrideDate,
+    @NotNull LocalDateTime startAt,
+    @NotNull LocalDateTime endAt
+) {
+
+  public UpdateScheduleCommand toCommand() {
+    return UpdateScheduleCommand.builder()
+        .parentScheduleId(parentScheduleId)
+        .targetScheduleId(targetScheduleId)
+        .title(title)
+        .memo(memo)
+        .alarmOffsetMinutes(alarmOffsetMinutes)
+        .overrideDate(overrideDate)
+        .startAt(startAt)
+        .endAt(endAt)
+        .build();
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/request/UpdateScheduleRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/request/UpdateScheduleRequest.java
@@ -1,6 +1,8 @@
 package com.rouby.schedule.presentation.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.rouby.schedule.application.dto.command.UpdateScheduleCommand;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -31,5 +33,11 @@ public record UpdateScheduleRequest(
         .startAt(startAt)
         .endAt(endAt)
         .build();
+  }
+
+  @AssertTrue(message = "종료 일자는 시작 일자보다 이후여야 합니다.")
+  @JsonIgnore
+  public boolean isValidPeriod() {
+    return endAt.isAfter(startAt);
   }
 }

--- a/back/src/test/java/com/rouby/schedule/fixture/UpdateScheduleRequestFixture.java
+++ b/back/src/test/java/com/rouby/schedule/fixture/UpdateScheduleRequestFixture.java
@@ -1,0 +1,34 @@
+package com.rouby.schedule.fixture;
+
+import com.rouby.schedule.presentation.dto.request.UpdateScheduleRequest;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class UpdateScheduleRequestFixture {
+
+  public static UpdateScheduleRequest getSuccessRequest() {
+    return new UpdateScheduleRequest(
+        1L,
+        2L,
+        "수정된 일정 제목",
+        "수정된 메모",
+        30,
+        LocalDate.of(2025, 9, 15),
+        LocalDateTime.of(2025, 9, 15, 10, 0),
+        LocalDateTime.of(2025, 9, 15, 12, 0)
+    );
+  }
+
+  public static UpdateScheduleRequest getAlarmOffsetFailedRequest() {
+    return new UpdateScheduleRequest(
+    1L,
+        2L,
+        "수정된 일정 제목",
+        "수정된 메모",
+        1340,
+        LocalDate.of(2025, 9, 15),
+        LocalDateTime.of(2025, 9, 15, 10, 0),
+        LocalDateTime.of(2025, 9, 15, 12, 0)
+    );
+  }
+}

--- a/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
+++ b/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -23,6 +24,7 @@ import com.rouby.common.support.ControllerTestSupport;
 import com.rouby.schedule.fixture.CreateScheduleRequestFixture;
 import com.rouby.schedule.fixture.GetScheduleRequestFixture;
 import com.rouby.schedule.fixture.SchedulesInfoFixture;
+import com.rouby.schedule.fixture.UpdateScheduleRequestFixture;
 import java.time.LocalDateTime;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
@@ -199,6 +201,76 @@ class ScheduleControllerTest extends ControllerTestSupport {
                 parameterWithName("fromAt").description("조회 시작 일시"),
                 parameterWithName("toAt").description("조회 종료 일시")
             ),
+            getErrorResponseFieldSnippet()
+        ));
+  }
+
+  @WithMockCustomUser
+  @DisplayName("스케쥴 수정 API - 성공 200")
+  @Test
+  void updateSchedule() throws Exception {
+
+    // given
+    var request = UpdateScheduleRequestFixture.getSuccessRequest();
+    var content = objectMapper.writeValueAsString(request);
+
+    when(scheduleFacade.updateSchedule(any(Long.class), any()))
+        .thenReturn(request.targetScheduleId());
+
+    // when
+    ResultActions resultActions = mockMvc.perform(put("/api/v1/schedules")
+        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+        .content(content)
+        .characterEncoding("UTF-8")
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andDo(print())
+        .andDo(document("update-schedule-200",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("parentScheduleId").description("부모 일정 아이디"),
+                fieldWithPath("targetScheduleId").description("수정할 타겟 일정 아이디"),
+                fieldWithPath("title").description("일정 제목"),
+                fieldWithPath("memo").description("일정 메모"),
+                fieldWithPath("alarmOffsetMinutes").description(
+                    "일정 전 알림 시간 설정 (5, 10, 15, 30 분 / 1, 2시간 / 1, 2 일 / 1주일 전)"),
+                fieldWithPath("overrideDate").description("예외 반복 변경 일자 (예: 2025-09-15)"),
+                fieldWithPath("startAt").description("수정된 시작 일시 (예: 2025-09-15T10:00:00)"),
+                fieldWithPath("endAt").description("수정된 종료 일시 (예: 2025-09-15T12:00:00)")
+            )
+        ));
+  }
+
+  @WithMockCustomUser
+  @DisplayName("스케쥴 수정 API - 알람 설정 시간 검증 실패 400")
+  @Test
+  void updateSchedule_failed_alarm_offset_validation() throws Exception {
+
+    // given
+    var request = UpdateScheduleRequestFixture.getAlarmOffsetFailedRequest();
+    var content = objectMapper.writeValueAsString(request);
+
+    doThrow(new IllegalArgumentException("지원되지 않는 알림 설정 시간(분) 정보입니다."))
+        .when(scheduleFacade).updateSchedule(any(Long.class), any());
+
+    // when
+    ResultActions resultActions = mockMvc.perform(put("/api/v1/schedules")
+        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+        .content(content)
+        .characterEncoding("UTF-8")
+        .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    resultActions.andExpect(status().isBadRequest())
+        .andDo(print())
+        .andDo(document("update-schedule-invalid-alarm-offset-400",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
             getErrorResponseFieldSnippet()
         ));
   }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #13

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 일정 수정 API 작성
  - [x] 부모 일정 수정
  - [x] 오버라이드 된 일정 수정

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 일정 업데이트 API(PUT /api/v1/schedules) 추가: 제목, 메모, 시작/종료 시각, 알림 오프셋 변경 가능.
  * 반복 일정의 특정 발생분만 개별 수정(overrideDate 기반 예외 수정) 지원.
  * 유효성 검증 강화: 필수 값, 제목/메모 길이, 알림 분(0~10080) 제한.
  * 대상 일정 미존재 시 404 오류와 안내 메시지 반환.
  * 처리 결과로 업데이트된 일정 ID 반환.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->