### PR TITLE
[#229][be][notification] 알림 배치 전송 서비스 구현

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -58,7 +58,10 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // Firebase Admin SDK
-    implementation 'com.google.firebase:firebase-admin:7.3.0'
+    implementation 'com.google.firebase:firebase-admin:9.6.0'
+
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/back/src/main/java/com/rouby/assistant/briefing/application/facade/BriefingFacade.java
+++ b/back/src/main/java/com/rouby/assistant/briefing/application/facade/BriefingFacade.java
@@ -6,7 +6,7 @@ import com.rouby.assistant.briefing.application.dto.info.CreatedBriefingResult;
 import com.rouby.assistant.briefing.application.service.BriefingService;
 import com.rouby.assistant.prompt.application.info.PromptInfo;
 import com.rouby.assistant.prompt.application.service.PromptReadService;
-import com.rouby.batch.job.briefing.dto.UserBriefingInfo;
+import com.rouby.batch.briefing.dto.UserBriefingInfo;
 import com.rouby.routine.routine_task.application.dto.command.GetRoutineTaskCommand;
 import com.rouby.routine.routine_task.application.service.RoutineTaskReadService;
 import com.rouby.schedule.application.dto.query.GetScheduleQuery;

--- a/back/src/main/java/com/rouby/batch/briefing/BriefingBatchConfig.java
+++ b/back/src/main/java/com/rouby/batch/briefing/BriefingBatchConfig.java
@@ -1,10 +1,10 @@
-package com.rouby.batch.config;
+package com.rouby.batch.briefing;
 
-import com.rouby.batch.job.briefing.dto.BriefingAggregate;
-import com.rouby.batch.job.briefing.dto.UserBriefingInfo;
-import com.rouby.batch.job.briefing.step.BriefingProcessor;
-import com.rouby.batch.job.briefing.step.BriefingReader;
-import com.rouby.batch.job.briefing.step.BriefingWriter;
+import com.rouby.batch.briefing.dto.BriefingAggregate;
+import com.rouby.batch.briefing.dto.UserBriefingInfo;
+import com.rouby.batch.briefing.step.BriefingProcessor;
+import com.rouby.batch.briefing.step.BriefingReader;
+import com.rouby.batch.briefing.step.BriefingWriter;
 import java.util.concurrent.Future;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
@@ -25,7 +25,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 @Configuration
 @EnableBatchProcessing
 @RequiredArgsConstructor
-public class BatchConfig {
+public class BriefingBatchConfig {
 
   private final BriefingReader briefingReader;
   private final BriefingProcessor briefingProcessor;

--- a/back/src/main/java/com/rouby/batch/briefing/BriefingQuartzJob.java
+++ b/back/src/main/java/com/rouby/batch/briefing/BriefingQuartzJob.java
@@ -1,4 +1,4 @@
-package com.rouby.batch;
+package com.rouby.batch.briefing;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @DisallowConcurrentExecution
 @RequiredArgsConstructor
-public class QuartzBriefingJob implements org.quartz.Job {
+public class BriefingQuartzJob implements org.quartz.Job {
 
   private final JobLauncher jobLauncher;
   private final Job briefingJob;

--- a/back/src/main/java/com/rouby/batch/briefing/dto/BriefingAggregate.java
+++ b/back/src/main/java/com/rouby/batch/briefing/dto/BriefingAggregate.java
@@ -1,4 +1,4 @@
-package com.rouby.batch.job.briefing.dto;
+package com.rouby.batch.briefing.dto;
 
 import com.rouby.assistant.briefing.application.dto.info.CreatedBriefingResult;
 import java.util.Objects;

--- a/back/src/main/java/com/rouby/batch/briefing/dto/BriefingNotificationEvents.java
+++ b/back/src/main/java/com/rouby/batch/briefing/dto/BriefingNotificationEvents.java
@@ -1,9 +1,10 @@
-package com.rouby.batch.job.briefing.dto;
+package com.rouby.batch.briefing.dto;
 
 import com.rouby.notification.notificationEvent.domain.entity.DeviceTokenInfo;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationMessage;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationType;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -14,7 +15,8 @@ public record BriefingNotificationEvents(
     String title,
     String body,
     String url,
-    NotificationType notificationType
+    NotificationType notificationType,
+    LocalDateTime dueAt
 ) {
 
   public List<NotificationEvent> toEntities() {
@@ -27,6 +29,7 @@ public record BriefingNotificationEvents(
             .deviceTokenInfo(deviceTokenInfo)
             .message(buildNotificationMessage())
             .type(notificationType)
+            .dueAt(dueAt)
             .build())
         .toList();
   }

--- a/back/src/main/java/com/rouby/batch/briefing/dto/UserBriefingInfo.java
+++ b/back/src/main/java/com/rouby/batch/briefing/dto/UserBriefingInfo.java
@@ -1,14 +1,16 @@
-package com.rouby.batch.job.briefing.dto;
+package com.rouby.batch.briefing.dto;
 
 import com.rouby.user.device.domain.entity.UserDevice;
 import com.rouby.user.user.application.dto.info.UserInfo;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 public record UserBriefingInfo(
     UserInfo userInfo,
     List<UserDevice> devices,
-    LocalDate today
+    LocalDate today,
+    LocalTime briefingTime
 ) {
 
 }

--- a/back/src/main/java/com/rouby/batch/briefing/step/BriefingProcessor.java
+++ b/back/src/main/java/com/rouby/batch/briefing/step/BriefingProcessor.java
@@ -1,17 +1,18 @@
-package com.rouby.batch.job.briefing.step;
+package com.rouby.batch.briefing.step;
 
 import static com.rouby.notification.notificationtemplate.domain.entity.NotificationType.BRIEFING;
 
 import com.rouby.assistant.briefing.application.dto.info.CreatedBriefingResult;
 import com.rouby.assistant.briefing.application.facade.BriefingFacade;
-import com.rouby.batch.job.briefing.dto.BriefingAggregate;
-import com.rouby.batch.job.briefing.dto.BriefingNotificationEvents;
-import com.rouby.batch.job.briefing.dto.UserBriefingInfo;
+import com.rouby.batch.briefing.dto.BriefingAggregate;
+import com.rouby.batch.briefing.dto.BriefingNotificationEvents;
+import com.rouby.batch.briefing.dto.UserBriefingInfo;
 import com.rouby.notification.notificationEvent.domain.entity.DeviceTokenInfo;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationType;
 import com.rouby.notification.notificationtemplate.application.dto.query.NotificationMessageQuery;
 import com.rouby.notification.notificationtemplate.application.service.NotificationTemplateReadService;
 import com.rouby.notification.notificationtemplate.domain.entity.Message;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
@@ -54,6 +55,7 @@ public class BriefingProcessor implements ItemProcessor<UserBriefingInfo, Briefi
         .body(message.getBody())
         .url(BriefingUrlPrefix + user.today().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
         .notificationType(NotificationType.BRIEFING)
+        .dueAt(LocalDateTime.of(user.today(), user.briefingTime()))
         .build();
 
     return new BriefingAggregate(briefing, events);

--- a/back/src/main/java/com/rouby/batch/briefing/step/BriefingReader.java
+++ b/back/src/main/java/com/rouby/batch/briefing/step/BriefingReader.java
@@ -1,6 +1,6 @@
-package com.rouby.batch.job.briefing.step;
+package com.rouby.batch.briefing.step;
 
-import com.rouby.batch.job.briefing.dto.UserBriefingInfo;
+import com.rouby.batch.briefing.dto.UserBriefingInfo;
 import com.rouby.user.device.application.dto.command.GetUserDeviceQuery;
 import com.rouby.user.device.application.service.UserDeviceReadService;
 import com.rouby.user.device.domain.entity.UserDevice;
@@ -47,9 +47,8 @@ public class BriefingReader extends ListItemReader<UserBriefingInfo> {
         .collect(Collectors.groupingBy(UserDevice::getUserId));
 
     return userInfos.stream()
-        .map(user -> new UserBriefingInfo(user,
-            deviceMap.getOrDefault(user.id(), List.of()),
-            today))
+        .map(user -> new UserBriefingInfo(
+            user, deviceMap.getOrDefault(user.id(), List.of()), today, targetTime))
         .toList();
   }
 }

--- a/back/src/main/java/com/rouby/batch/briefing/step/BriefingWriter.java
+++ b/back/src/main/java/com/rouby/batch/briefing/step/BriefingWriter.java
@@ -1,8 +1,8 @@
-package com.rouby.batch.job.briefing.step;
+package com.rouby.batch.briefing.step;
 
 import com.rouby.assistant.briefing.domain.Briefing;
 import com.rouby.assistant.briefing.domain.repository.BriefingRepository;
-import com.rouby.batch.job.briefing.dto.BriefingAggregate;
+import com.rouby.batch.briefing.dto.BriefingAggregate;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
 import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
 import java.util.List;

--- a/back/src/main/java/com/rouby/batch/config/QuartzConfig.java
+++ b/back/src/main/java/com/rouby/batch/config/QuartzConfig.java
@@ -1,6 +1,6 @@
 package com.rouby.batch.config;
 
-import com.rouby.batch.QuartzBriefingJob;
+import com.rouby.batch.briefing.BriefingQuartzJob;
 import java.util.TimeZone;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.JobBuilder;
@@ -22,7 +22,7 @@ public class QuartzConfig {
 
   @Bean
   public JobDetail briefingJobDetail() {
-    return JobBuilder.newJob(QuartzBriefingJob.class)
+    return JobBuilder.newJob(BriefingQuartzJob.class)
         .withIdentity("briefingJob")
         .storeDurably()
         .build();

--- a/back/src/main/java/com/rouby/batch/config/QuartzConfig.java
+++ b/back/src/main/java/com/rouby/batch/config/QuartzConfig.java
@@ -1,6 +1,7 @@
 package com.rouby.batch.config;
 
 import com.rouby.batch.briefing.BriefingQuartzJob;
+import com.rouby.batch.notification.NotificationQuartzJob;
 import java.util.TimeZone;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.JobBuilder;
@@ -37,6 +38,27 @@ public class QuartzConfig {
             CronScheduleBuilder.cronSchedule(briefingCron)
                 .inTimeZone(TimeZone.getTimeZone(briefingTimeZone))
                 .withMisfireHandlingInstructionIgnoreMisfires()
+        )
+        .build();
+  }
+
+  @Bean
+  JobDetail notificationEventDispatchJob() {
+    return JobBuilder.newJob(NotificationQuartzJob.class)
+        .withIdentity("dispatch")
+        .storeDurably()
+        .build();
+  }
+
+  @Bean
+  Trigger dispatchTrigger(JobDetail notificationEventDispatchJob) {
+
+    return TriggerBuilder.newTrigger()
+        .forJob(notificationEventDispatchJob).withIdentity("dispatchTrigger")
+        .withSchedule(
+            CronScheduleBuilder.cronSchedule("55 * * * * ?")
+                .inTimeZone(TimeZone.getTimeZone("Asia/Seoul"))
+                .withMisfireHandlingInstructionFireAndProceed()
         )
         .build();
   }

--- a/back/src/main/java/com/rouby/batch/config/QuartzConfig.java
+++ b/back/src/main/java/com/rouby/batch/config/QuartzConfig.java
@@ -43,15 +43,15 @@ public class QuartzConfig {
   }
 
   @Bean
-  JobDetail notificationEventDispatchJob() {
+  public JobDetail notificationEventDispatchJob() {
     return JobBuilder.newJob(NotificationQuartzJob.class)
-        .withIdentity("dispatch")
+        .withIdentity("notificationDispatchJob")
         .storeDurably()
         .build();
   }
 
   @Bean
-  Trigger dispatchTrigger(JobDetail notificationEventDispatchJob) {
+  public Trigger dispatchTrigger(JobDetail notificationEventDispatchJob) {
 
     return TriggerBuilder.newTrigger()
         .forJob(notificationEventDispatchJob).withIdentity("dispatchTrigger")

--- a/back/src/main/java/com/rouby/batch/notification/DbWriterAdapter.java
+++ b/back/src/main/java/com/rouby/batch/notification/DbWriterAdapter.java
@@ -1,0 +1,26 @@
+package com.rouby.batch.notification;
+
+import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DbWriterAdapter {
+
+  private final NotificationEventRepository repo;
+
+  @CircuitBreaker(name = "dbWriter")
+  @Retry(name = "dbWriter")
+  public void markSentResilient(java.util.List<Long> ids, String workerId) {
+    repo.markSent(ids, workerId);
+  }
+
+  @CircuitBreaker(name = "dbWriter")
+  @Retry(name = "dbWriter")
+  public void markRetryResilient(java.util.List<Long> ids, String workerId) {
+    repo.markRetry(ids, workerId);
+  }
+}

--- a/back/src/main/java/com/rouby/batch/notification/DbWriterAdapter.java
+++ b/back/src/main/java/com/rouby/batch/notification/DbWriterAdapter.java
@@ -1,8 +1,9 @@
 package com.rouby.batch.notification;
 
+import com.rouby.notification.notificationEvent.domain.info.SuccessResult;
 import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.retry.annotation.Retry;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,14 +14,14 @@ public class DbWriterAdapter {
   private final NotificationEventRepository repo;
 
   @CircuitBreaker(name = "dbWriter")
-  @Retry(name = "dbWriter")
-  public void markSentResilient(java.util.List<Long> ids, String workerId) {
-    repo.markSent(ids, workerId);
+  public int markSentResilient(List<SuccessResult> successResults, String workerId) {
+    if (successResults == null || successResults.isEmpty()) return 0;
+    return repo.markSent(successResults, workerId);
   }
 
   @CircuitBreaker(name = "dbWriter")
-  @Retry(name = "dbWriter")
-  public void markRetryResilient(java.util.List<Long> ids, String workerId) {
-    repo.markRetry(ids, workerId);
+  public int markRetryResilient(List<Long> ids, String workerId) {
+    if (ids == null || ids.isEmpty()) return 0;
+    return repo.markRetry(ids, workerId);
   }
 }

--- a/back/src/main/java/com/rouby/batch/notification/DefaultDispatcher.java
+++ b/back/src/main/java/com/rouby/batch/notification/DefaultDispatcher.java
@@ -4,11 +4,11 @@ import com.rouby.notification.notificationEvent.domain.info.NotificationEventInf
 import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
 import com.rouby.notification.notificationEvent.domain.sender.AsyncNotificationSender;
 import com.rouby.notification.notificationEvent.domain.sender.NotificationSender;
+import jakarta.annotation.PostConstruct;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -17,19 +17,19 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import org.quartz.JobExecutionContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DefaultDispatcher implements NotificationDispatcher {
 
-  private final Clock clock = Clock.systemUTC();
+  private final Clock clock;
 
-  private final Semaphore inFlight = new Semaphore(512);
   @Qualifier("notificationSendExecutor")
   private final ThreadPoolTaskExecutor notificationSendExecutor;
   @Qualifier("resultCallbackExecutor")
@@ -58,20 +58,28 @@ public class DefaultDispatcher implements NotificationDispatcher {
   private int ONTIME_TTL;
   @Value("${notification.dispatch.ttl.backfillSec:600}")
   private int BACKFILL_TTL;
-  @Value("${notification.dispatch.lease.ontimeSec:60}")
-  int LEASE_ONTIME_SEC;
+  @Value("${notification.dispatch.lease.ontimeSec:45}")
+  private int LEASE_ONTIME_SEC;
   @Value("${notification.dispatch.lease.backfillSec:30}")
-  int LEASE_BACKFILL_SEC;
+  private int LEASE_BACKFILL_SEC;
+
+  @Value("${notification.dispatch.maxConcurrent:512}")
+  private int MAX_CONCURRENT;
+  private Semaphore inFlight;
+
+  @PostConstruct
+  public void init() {
+    this.inFlight = new Semaphore(MAX_CONCURRENT);
+  }
 
   @Override
-  public void dispatch(JobExecutionContext ctx) {
+  public void dispatch(Instant sched) {
 
     // 자기치유
     notificationEventRepository.recoverExpiredLeases();
 
-    ZonedDateTime sched = ZonedDateTime.ofInstant(
-        ctx.getScheduledFireTime().toInstant(), ZoneId.of("Asia/Seoul")); // M:55
-    Instant nextSched = sched.plusMinutes(1).toInstant(); // (M+1):55
+    // sched M:55
+    Instant nextSched = sched.plus(1, ChronoUnit.MINUTES); // (M+1):55
 
     long possibleMsToNextSched = Math.max(0, Duration.between(Instant.now(clock), nextSched.minusMillis(GUARD_MS)).toMillis());
     long budgetMs = Math.max(0, Math.min(TIME_BUDGET_SEC * 1000L, possibleMsToNextSched));
@@ -81,42 +89,55 @@ public class DefaultDispatcher implements NotificationDispatcher {
     backfillSendAsync(deadlineNano);
   }
 
-  private void ontimeSendAsync(ZonedDateTime sched, long deadlineNano) {
+  private void ontimeSendAsync(Instant sched, long deadlineNano) {
 
     // 온타임: [slotStart, slotEnd)만 클레임 → 타이머 예약
     // 다음 트리거(nextSched) 직전까지만, guard 남기고 실행
-    Instant slotStart = sched.truncatedTo(ChronoUnit.MINUTES).plusMinutes(1).toInstant(); // M+1:00
+    Instant slotStart = sched.truncatedTo(ChronoUnit.MINUTES).plus(1, ChronoUnit.MINUTES); // M+1:00
     Instant slotEnd   = slotStart.plus(1, ChronoUnit.MINUTES); // M+2:00
-
+    boolean start = true;
     List<NotificationEventInfo> ontime;
     do {
       ontime = notificationEventRepository.claimSlot(slotStart, slotEnd, LIMIT, writer.workerId(), LEASE_ONTIME_SEC);
       for (NotificationEventInfo ev : ontime) {
 
         long delayMs = Math.max(
-            0, Duration.between(Instant.now(clock), ev.dueAt().minusMillis(LEAD_MS)).toMillis());
+            0, Duration.between(Instant.now(clock),
+                ev.dueAt().atZone(ZoneId.of("Asia/Seoul")).toInstant().minusMillis(LEAD_MS)).toMillis());
         preciseTimer.schedule(() -> {
           if (!inFlight.tryAcquire()) { writer.reportFailure(ev.id()); return; }
           long sentAt = clock.millis();
           sender.sendAsync(ev, ONTIME_TTL, sentAt, true)
-              .whenCompleteAsync((ok, ex) -> {
+              .whenComplete((ok, ex) -> {
                 try {
-                  if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id());
-                  else writer.reportFailure(ev.id());
+                  if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id(), sentAt);
+                  else {
+                    writer.reportFailure(ev.id());
+                    if (ex != null) {
+                      log.error("fcm 알림 발송 처리 실패", ex);
+                    } else {
+                      log.warn("fcm 알림 발송 처리 실패: 응답은 false (예외 없음)");
+                    }
+                  }
                 } finally {
                   inFlight.release();
                 }
-              }, resultCallbackExecutor);
+              });
           }, delayMs, TimeUnit.MILLISECONDS);
+      }
+
+      if (start) {
+        writer.requestFlush();
+        start = false;
       }
     } while (!ontime.isEmpty() && System.nanoTime() < deadlineNano);
   }
 
-  private void ontimeSend(ZonedDateTime sched, long deadlineNano) {
+  private void ontimeSend(Instant sched, long deadlineNano) {
 
     // 온타임: [slotStart, slotEnd)만 클레임 → 타이머 예약
     // 다음 트리거(nextSched) 직전까지만, guard 남기고 실행
-    Instant slotStart = sched.truncatedTo(ChronoUnit.MINUTES).plusMinutes(1).toInstant(); // M+1:00
+    Instant slotStart = sched.truncatedTo(ChronoUnit.MINUTES).plus(1, ChronoUnit.MINUTES); // M+1:00
     Instant slotEnd   = slotStart.plus(1, ChronoUnit.MINUTES); // M+2:00
 
     List<NotificationEventInfo> ontime;
@@ -125,7 +146,8 @@ public class DefaultDispatcher implements NotificationDispatcher {
       for (NotificationEventInfo ev : ontime) {
 
         long delayMs = Math.max(
-            0, Duration.between(Instant.now(clock), ev.dueAt().minusMillis(LEAD_MS)).toMillis());
+            0, Duration.between(Instant.now(clock),
+                ev.dueAt().atZone(ZoneId.of("Asia/Seoul")).toInstant().minusMillis(LEAD_MS)).toMillis());
         preciseTimer.schedule(() -> {
           try {
             CompletableFuture.supplyAsync(() -> {
@@ -134,7 +156,7 @@ public class DefaultDispatcher implements NotificationDispatcher {
                     },
                   notificationSendExecutor)
               .whenCompleteAsync((ok, ex) -> {
-                if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id());
+                if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id(), clock.millis());
                 else writer.reportFailure(ev.id());
               }, resultCallbackExecutor);
           } catch (RejectedExecutionException rex) {
@@ -155,17 +177,27 @@ public class DefaultDispatcher implements NotificationDispatcher {
 
       for (NotificationEventInfo ev : late) {
 
-        if (!inFlight.tryAcquire()) { writer.reportFailure(ev.id()); return; }
+        if (!inFlight.tryAcquire()) {
+          writer.reportFailure(ev.id());
+          continue;
+        }
         long sentAt = clock.millis();
         sender.sendAsync(ev, BACKFILL_TTL, sentAt, true)
-            .whenCompleteAsync((ok, ex) -> {
+            .whenComplete((ok, ex) -> {
               try {
-                if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id());
-                else writer.reportFailure(ev.id());
+                if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id(), sentAt);
+                else {
+                  writer.reportFailure(ev.id());
+                  if (ex != null) {
+                    log.error("fcm 알림 발송 처리 실패", ex);
+                  } else {
+                    log.warn("fcm 알림 발송 처리 실패: 응답은 false (예외 없음)");
+                  }
+                }
               } finally {
                 inFlight.release();
               }
-            }, resultCallbackExecutor);
+            });
       }
     }
   }
@@ -186,7 +218,7 @@ public class DefaultDispatcher implements NotificationDispatcher {
                 },
                 notificationSendExecutor)
             .whenCompleteAsync((ok, ex) -> {
-              if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id());
+              if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id(), clock.millis());
               else writer.reportFailure(ev.id());
             }, resultCallbackExecutor);
       }

--- a/back/src/main/java/com/rouby/batch/notification/DefaultDispatcher.java
+++ b/back/src/main/java/com/rouby/batch/notification/DefaultDispatcher.java
@@ -1,0 +1,195 @@
+package com.rouby.batch.notification;
+
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
+import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
+import com.rouby.notification.notificationEvent.domain.sender.AsyncNotificationSender;
+import com.rouby.notification.notificationEvent.domain.sender.NotificationSender;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DefaultDispatcher implements NotificationDispatcher {
+
+  private final Clock clock = Clock.systemUTC();
+
+  private final Semaphore inFlight = new Semaphore(512);
+  @Qualifier("notificationSendExecutor")
+  private final ThreadPoolTaskExecutor notificationSendExecutor;
+  @Qualifier("resultCallbackExecutor")
+  private final ThreadPoolTaskExecutor resultCallbackExecutor;
+  @Qualifier("preciseTimer")
+  private final ScheduledExecutorService preciseTimer;
+  private final NotificationEventRepository notificationEventRepository;
+  private final AsyncNotificationSender sender;
+  private final NotificationSender basicSender;
+  private final ResultWriter writer;
+
+  @Value("${notification.dispatch.timeBudgetSec:50}")
+  private int TIME_BUDGET_SEC;
+  @Value("${notification.dispatch.leadMs:600}")
+  private long LEAD_MS;
+  @Value("${notification.dispatch.guardMs:500}")
+  private long GUARD_MS; // 정각 0.5초 전에는 무조건 종료
+
+  @Value("${notification.dispatch.limit:200}")
+  private int LIMIT;
+  @Value("${notification.dispatch.maxAttempt:3}")
+  int MAX_ATTEMPT;
+  @Value("${notification.dispatch.backfillMinutes:10}")
+  private int BACKFILL_MIN;
+  @Value("${notification.dispatch.ttl.ontimeSec:60}")
+  private int ONTIME_TTL;
+  @Value("${notification.dispatch.ttl.backfillSec:600}")
+  private int BACKFILL_TTL;
+  @Value("${notification.dispatch.lease.ontimeSec:60}")
+  int LEASE_ONTIME_SEC;
+  @Value("${notification.dispatch.lease.backfillSec:30}")
+  int LEASE_BACKFILL_SEC;
+
+  @Override
+  public void dispatch(JobExecutionContext ctx) {
+
+    // 자기치유
+    notificationEventRepository.recoverExpiredLeases();
+
+    ZonedDateTime sched = ZonedDateTime.ofInstant(
+        ctx.getScheduledFireTime().toInstant(), ZoneId.of("Asia/Seoul")); // M:55
+    Instant nextSched = sched.plusMinutes(1).toInstant(); // (M+1):55
+
+    long possibleMsToNextSched = Math.max(0, Duration.between(Instant.now(clock), nextSched.minusMillis(GUARD_MS)).toMillis());
+    long budgetMs = Math.max(0, Math.min(TIME_BUDGET_SEC * 1000L, possibleMsToNextSched));
+    long deadlineNano = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(budgetMs);
+
+    ontimeSendAsync(sched, deadlineNano);
+    backfillSendAsync(deadlineNano);
+  }
+
+  private void ontimeSendAsync(ZonedDateTime sched, long deadlineNano) {
+
+    // 온타임: [slotStart, slotEnd)만 클레임 → 타이머 예약
+    // 다음 트리거(nextSched) 직전까지만, guard 남기고 실행
+    Instant slotStart = sched.truncatedTo(ChronoUnit.MINUTES).plusMinutes(1).toInstant(); // M+1:00
+    Instant slotEnd   = slotStart.plus(1, ChronoUnit.MINUTES); // M+2:00
+
+    List<NotificationEventInfo> ontime;
+    do {
+      ontime = notificationEventRepository.claimSlot(slotStart, slotEnd, LIMIT, writer.workerId(), LEASE_ONTIME_SEC);
+      for (NotificationEventInfo ev : ontime) {
+
+        long delayMs = Math.max(
+            0, Duration.between(Instant.now(clock), ev.dueAt().minusMillis(LEAD_MS)).toMillis());
+        preciseTimer.schedule(() -> {
+          if (!inFlight.tryAcquire()) { writer.reportFailure(ev.id()); return; }
+          long sentAt = clock.millis();
+          sender.sendAsync(ev, ONTIME_TTL, sentAt, true)
+              .whenCompleteAsync((ok, ex) -> {
+                try {
+                  if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id());
+                  else writer.reportFailure(ev.id());
+                } finally {
+                  inFlight.release();
+                }
+              }, resultCallbackExecutor);
+          }, delayMs, TimeUnit.MILLISECONDS);
+      }
+    } while (!ontime.isEmpty() && System.nanoTime() < deadlineNano);
+  }
+
+  private void ontimeSend(ZonedDateTime sched, long deadlineNano) {
+
+    // 온타임: [slotStart, slotEnd)만 클레임 → 타이머 예약
+    // 다음 트리거(nextSched) 직전까지만, guard 남기고 실행
+    Instant slotStart = sched.truncatedTo(ChronoUnit.MINUTES).plusMinutes(1).toInstant(); // M+1:00
+    Instant slotEnd   = slotStart.plus(1, ChronoUnit.MINUTES); // M+2:00
+
+    List<NotificationEventInfo> ontime;
+    do {
+      ontime = notificationEventRepository.claimSlot(slotStart, slotEnd, LIMIT, writer.workerId(), LEASE_ONTIME_SEC);
+      for (NotificationEventInfo ev : ontime) {
+
+        long delayMs = Math.max(
+            0, Duration.between(Instant.now(clock), ev.dueAt().minusMillis(LEAD_MS)).toMillis());
+        preciseTimer.schedule(() -> {
+          try {
+            CompletableFuture.supplyAsync(() -> {
+                      long sentAt = clock.millis();
+                      return basicSender.send(ev, ONTIME_TTL, sentAt, true);
+                    },
+                  notificationSendExecutor)
+              .whenCompleteAsync((ok, ex) -> {
+                if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id());
+                else writer.reportFailure(ev.id());
+              }, resultCallbackExecutor);
+          } catch (RejectedExecutionException rex) {
+            writer.reportFailure(ev.id());
+          }}, delayMs, TimeUnit.MILLISECONDS);
+      }
+    } while (!ontime.isEmpty() && System.nanoTime() < deadlineNano);
+  }
+
+  private void backfillSendAsync(long deadlineNano) {
+
+    // 백필: 다음 트리거(nextSched) 직전까지만, guard 남기고 실행
+    while (System.nanoTime() < deadlineNano) {
+
+      List<NotificationEventInfo> late = notificationEventRepository.claimBackfill(
+          BACKFILL_MIN, MAX_ATTEMPT, LIMIT, writer.workerId(), LEASE_BACKFILL_SEC);
+      if (late.isEmpty()) break;
+
+      for (NotificationEventInfo ev : late) {
+
+        if (!inFlight.tryAcquire()) { writer.reportFailure(ev.id()); return; }
+        long sentAt = clock.millis();
+        sender.sendAsync(ev, BACKFILL_TTL, sentAt, true)
+            .whenCompleteAsync((ok, ex) -> {
+              try {
+                if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id());
+                else writer.reportFailure(ev.id());
+              } finally {
+                inFlight.release();
+              }
+            }, resultCallbackExecutor);
+      }
+    }
+  }
+
+  private void backfillSend(long deadlineNano) {
+
+    // 백필: 다음 트리거(nextSched) 직전까지만, guard 남기고 실행
+    while (System.nanoTime() < deadlineNano) {
+
+      List<NotificationEventInfo> late = notificationEventRepository.claimBackfill(
+          BACKFILL_MIN, MAX_ATTEMPT, LIMIT, writer.workerId(), LEASE_BACKFILL_SEC);
+      if (late.isEmpty()) break;
+
+      for (NotificationEventInfo ev : late) {
+        CompletableFuture.supplyAsync(() -> {
+                  long sentAt = clock.millis();
+                  return basicSender.send(ev, BACKFILL_TTL, sentAt, true);
+                },
+                notificationSendExecutor)
+            .whenCompleteAsync((ok, ex) -> {
+              if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id());
+              else writer.reportFailure(ev.id());
+            }, resultCallbackExecutor);
+      }
+    }
+  }
+}

--- a/back/src/main/java/com/rouby/batch/notification/DefaultDispatcher.java
+++ b/back/src/main/java/com/rouby/batch/notification/DefaultDispatcher.java
@@ -4,6 +4,11 @@ import com.rouby.notification.notificationEvent.domain.info.NotificationEventInf
 import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
 import com.rouby.notification.notificationEvent.domain.sender.AsyncNotificationSender;
 import com.rouby.notification.notificationEvent.domain.sender.NotificationSender;
+import com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventFcmException;
+import com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventFcmRetryableException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import jakarta.annotation.PostConstruct;
 import java.time.Clock;
 import java.time.Duration;
@@ -12,10 +17,13 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -29,6 +37,7 @@ import org.springframework.stereotype.Component;
 public class DefaultDispatcher implements NotificationDispatcher {
 
   private final Clock clock;
+  private final CircuitBreakerRegistry cbRegistry;
 
   @Qualifier("notificationSendExecutor")
   private final ThreadPoolTaskExecutor notificationSendExecutor;
@@ -107,22 +116,7 @@ public class DefaultDispatcher implements NotificationDispatcher {
         preciseTimer.schedule(() -> {
           if (!inFlight.tryAcquire()) { writer.reportFailure(ev.id()); return; }
           long sentAt = clock.millis();
-          sender.sendAsync(ev, ONTIME_TTL, sentAt, true)
-              .whenComplete((ok, ex) -> {
-                try {
-                  if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id(), sentAt);
-                  else {
-                    writer.reportFailure(ev.id());
-                    if (ex != null) {
-                      log.error("fcm 알림 발송 처리 실패", ex);
-                    } else {
-                      log.warn("fcm 알림 발송 처리 실패: 응답은 false (예외 없음)");
-                    }
-                  }
-                } finally {
-                  inFlight.release();
-                }
-              });
+          sendWithCbRetry(ev, ONTIME_TTL, sentAt, true, deadlineNano, 1, 3);
           }, delayMs, TimeUnit.MILLISECONDS);
       }
 
@@ -131,6 +125,89 @@ public class DefaultDispatcher implements NotificationDispatcher {
         start = false;
       }
     } while (!ontime.isEmpty() && System.nanoTime() < deadlineNano);
+  }
+
+
+  private void backfillSendAsync(long deadlineNano) {
+
+    // 백필: 다음 트리거(nextSched) 직전까지만, guard 남기고 실행
+    while (System.nanoTime() < deadlineNano) {
+
+      List<NotificationEventInfo> late = notificationEventRepository.claimBackfill(
+          BACKFILL_MIN, MAX_ATTEMPT, LIMIT, writer.workerId(), LEASE_BACKFILL_SEC);
+      if (late.isEmpty()) break;
+
+      for (NotificationEventInfo ev : late) {
+
+        if (!inFlight.tryAcquire()) {
+          writer.reportFailure(ev.id());
+          continue;
+        }
+        long sentAt = clock.millis();
+        sendWithCbRetry(ev, BACKFILL_TTL, sentAt, true, deadlineNano, 1, 3);
+      }
+    }
+  }
+
+  private void sendWithCbRetry(NotificationEventInfo ev, int ttl, long sentAt,
+      boolean highPriority, long deadlineNano, int attempt, int maxAttempts) {
+
+    CircuitBreaker fcmCb = cbRegistry.circuitBreaker("fcm");
+    Supplier<CompletionStage<Boolean>> call =
+        CircuitBreaker.decorateCompletionStage(fcmCb, () -> sender.sendAsync(ev, ttl, sentAt, highPriority));
+
+    call.get().whenCompleteAsync((ok, ex) -> {
+      try {
+        boolean success = (ex == null && Boolean.TRUE.equals(ok));
+        if (success) { writer.reportSuccess(ev.id(), sentAt); return; }
+
+        if (ex instanceof CallNotPermittedException) {
+          writer.reportFailure(ev.id());
+          return;
+        }
+        if (!isTransient(ex)) {
+          writer.reportFailure(ev.id());
+          return;
+        }
+        if (attempt >= maxAttempts || System.nanoTime() >= deadlineNano) {
+          writer.reportFailure(ev.id());
+          return;
+        }
+
+        long backoffMs = computeBackoffMs(ex, attempt);
+        long next = clock.instant().getNano() + TimeUnit.MILLISECONDS.toNanos(backoffMs);
+        if (next >= deadlineNano) { writer.reportFailure(ev.id()); return; }
+
+        preciseTimer.schedule(
+            () -> sendWithCbRetry(ev, ttl, sentAt, highPriority, deadlineNano, attempt + 1, maxAttempts),
+            backoffMs, TimeUnit.MILLISECONDS);
+      } finally {
+        inFlight.release();
+      }
+    }, resultCallbackExecutor);
+  }
+
+  private boolean isTransient(Throwable t) {
+    Throwable root = (t.getCause() != null) ? t.getCause() : t;
+    if (root instanceof NotificationEventFcmException fe) {
+      int s = fe.getStatus().value();
+      return s == 429 || (s >= 500 && s < 600);
+    }
+    return (root instanceof java.util.concurrent.TimeoutException)
+        || (root instanceof reactor.netty.http.client.PrematureCloseException);
+  }
+
+  private long computeBackoffMs(Throwable t, int attempt) {
+    long base = 200L, max = 2_000L;
+    long exponential = Math.min(max, base << (attempt - 1));
+
+    Long retryAfter = (t instanceof NotificationEventFcmRetryableException fe) ? Long.valueOf(fe.getRetryAfter()) : null;
+    long ms = (retryAfter != null && retryAfter > 0) ? Math.max(exponential, retryAfter * 1000L) : exponential;
+
+    long jitter = (long)(ms * 0.2);
+    long delta = ThreadLocalRandom.current().nextLong(-jitter, jitter + 1);
+
+    return Math.max(100L, ms + delta);
   }
 
   private void ontimeSend(Instant sched, long deadlineNano) {
@@ -154,52 +231,16 @@ public class DefaultDispatcher implements NotificationDispatcher {
                       long sentAt = clock.millis();
                       return basicSender.send(ev, ONTIME_TTL, sentAt, true);
                     },
-                  notificationSendExecutor)
-              .whenCompleteAsync((ok, ex) -> {
-                if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id(), clock.millis());
-                else writer.reportFailure(ev.id());
-              }, resultCallbackExecutor);
+                    notificationSendExecutor)
+                .whenCompleteAsync((ok, ex) -> {
+                  if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id(), clock.millis());
+                  else writer.reportFailure(ev.id());
+                }, resultCallbackExecutor);
           } catch (RejectedExecutionException rex) {
             writer.reportFailure(ev.id());
           }}, delayMs, TimeUnit.MILLISECONDS);
       }
     } while (!ontime.isEmpty() && System.nanoTime() < deadlineNano);
-  }
-
-  private void backfillSendAsync(long deadlineNano) {
-
-    // 백필: 다음 트리거(nextSched) 직전까지만, guard 남기고 실행
-    while (System.nanoTime() < deadlineNano) {
-
-      List<NotificationEventInfo> late = notificationEventRepository.claimBackfill(
-          BACKFILL_MIN, MAX_ATTEMPT, LIMIT, writer.workerId(), LEASE_BACKFILL_SEC);
-      if (late.isEmpty()) break;
-
-      for (NotificationEventInfo ev : late) {
-
-        if (!inFlight.tryAcquire()) {
-          writer.reportFailure(ev.id());
-          continue;
-        }
-        long sentAt = clock.millis();
-        sender.sendAsync(ev, BACKFILL_TTL, sentAt, true)
-            .whenComplete((ok, ex) -> {
-              try {
-                if (ex == null && Boolean.TRUE.equals(ok)) writer.reportSuccess(ev.id(), sentAt);
-                else {
-                  writer.reportFailure(ev.id());
-                  if (ex != null) {
-                    log.error("fcm 알림 발송 처리 실패", ex);
-                  } else {
-                    log.warn("fcm 알림 발송 처리 실패: 응답은 false (예외 없음)");
-                  }
-                }
-              } finally {
-                inFlight.release();
-              }
-            });
-      }
-    }
   }
 
   private void backfillSend(long deadlineNano) {

--- a/back/src/main/java/com/rouby/batch/notification/NotificationDispatcher.java
+++ b/back/src/main/java/com/rouby/batch/notification/NotificationDispatcher.java
@@ -1,0 +1,8 @@
+package com.rouby.batch.notification;
+
+import org.quartz.JobExecutionContext;
+
+public interface NotificationDispatcher {
+
+  void dispatch(JobExecutionContext ctx);
+}

--- a/back/src/main/java/com/rouby/batch/notification/NotificationDispatcher.java
+++ b/back/src/main/java/com/rouby/batch/notification/NotificationDispatcher.java
@@ -1,8 +1,8 @@
 package com.rouby.batch.notification;
 
-import org.quartz.JobExecutionContext;
+import java.time.Instant;
 
 public interface NotificationDispatcher {
 
-  void dispatch(JobExecutionContext ctx);
+  void dispatch(Instant sched);
 }

--- a/back/src/main/java/com/rouby/batch/notification/NotificationQuartzJob.java
+++ b/back/src/main/java/com/rouby/batch/notification/NotificationQuartzJob.java
@@ -1,18 +1,16 @@
 package com.rouby.batch.notification;
 
 import lombok.RequiredArgsConstructor;
-import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 
 @RequiredArgsConstructor
-@DisallowConcurrentExecution
 public class NotificationQuartzJob implements Job {
 
   private final NotificationDispatcher dispatcher;
 
   @Override
   public void execute(JobExecutionContext ctx) {
-    dispatcher.dispatch(ctx);
+    dispatcher.dispatch(ctx.getScheduledFireTime().toInstant());
   }
 }

--- a/back/src/main/java/com/rouby/batch/notification/NotificationQuartzJob.java
+++ b/back/src/main/java/com/rouby/batch/notification/NotificationQuartzJob.java
@@ -1,0 +1,18 @@
+package com.rouby.batch.notification;
+
+import lombok.RequiredArgsConstructor;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+
+@RequiredArgsConstructor
+@DisallowConcurrentExecution
+public class NotificationQuartzJob implements Job {
+
+  private final NotificationDispatcher dispatcher;
+
+  @Override
+  public void execute(JobExecutionContext ctx) {
+    dispatcher.dispatch(ctx);
+  }
+}

--- a/back/src/main/java/com/rouby/batch/notification/ResultWriter.java
+++ b/back/src/main/java/com/rouby/batch/notification/ResultWriter.java
@@ -1,0 +1,140 @@
+package com.rouby.batch.notification;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ResultWriter implements AutoCloseable {
+
+  @Value("${notification.writer.flush.batch:500}")
+  int FLUSH_BATCH_SIZE;
+  @Value("${notification.writer.flush.intervalMs:200}")
+  long INTERVAL_MS;
+
+  private final CircuitBreakerRegistry cbRegistry;
+  @Qualifier("flushScheduler")
+  private final ScheduledExecutorService flushScheduler;
+  private final DbWriterAdapter dbWriterAdapter;
+
+  private final String workerId = UUID.randomUUID().toString();
+
+  private final BlockingQueue<Long> okQ     = new LinkedBlockingQueue<>(10_000);
+  private final BlockingQueue<Long> failQ   = new LinkedBlockingQueue<>(10_000);
+
+  public String workerId() { return workerId; }
+
+  @PostConstruct
+  void start() {
+    flushScheduler.scheduleAtFixedRate(this::flushTick, INTERVAL_MS, INTERVAL_MS, TimeUnit.MILLISECONDS);
+  }
+
+  private void flushTick() {
+    CircuitBreaker cb = cbRegistry.circuitBreaker("dbWriter");
+
+    if (cb.getState() == CircuitBreaker.State.OPEN) return;
+    drainAndUpdate(okQ,   true);
+
+    if (cb.getState() == CircuitBreaker.State.OPEN) return;
+    drainAndUpdate(failQ, false);
+  }
+
+  public void reportSuccess(long id) {
+    try {
+      if (!okQ.offer(id)) {
+        int size = okQ.size(), rem = okQ.remainingCapacity();
+        log.atError()
+            .addKeyValue("queue", "okQ")
+            .addKeyValue("eventId", id)
+            .addKeyValue("size", size)
+            .addKeyValue("remaining", rem)
+            .addKeyValue("capacity", size + rem)
+            .log("enqueue overflow: dropped");
+      }
+    } catch (Exception e) {
+      log.atError()
+          .addKeyValue("queue", "okQ")
+          .addKeyValue("eventId", id)
+          .addKeyValue("size", okQ.size())
+          .addKeyValue("remaining", okQ.remainingCapacity())
+          .setCause(e)
+          .log("enqueue error");
+    }
+  }
+  public void reportFailure(long id) {
+    try {
+      if (!failQ.offer(id)) {
+        int size = failQ.size(), rem = failQ.remainingCapacity();
+        log.atError()
+            .addKeyValue("queue", "failQ")
+            .addKeyValue("eventId", id)
+            .addKeyValue("size", size)
+            .addKeyValue("remaining", rem)
+            .addKeyValue("capacity", size + rem)
+            .log("enqueue overflow: dropped");
+      }
+    } catch (Exception e) {
+      log.atError()
+          .addKeyValue("queue", "failQ")
+          .addKeyValue("eventId", id)
+          .addKeyValue("size", failQ.size())
+          .addKeyValue("remaining", failQ.remainingCapacity())
+          .setCause(e)
+          .log("enqueue error");
+    }
+  }
+
+  private void drainAndUpdate(BlockingQueue<Long> q, boolean success) {
+
+    CircuitBreaker cb = cbRegistry.circuitBreaker("dbWriter");
+    int batchSize = (cb.getState() == CircuitBreaker.State.HALF_OPEN)
+        ? Math.min(FLUSH_BATCH_SIZE, 50)
+        : FLUSH_BATCH_SIZE;
+
+    while (true) {
+      ArrayList<Long> inFlight = new ArrayList<>(batchSize);
+      q.drainTo(inFlight, batchSize);
+
+      if (inFlight.isEmpty()) break;
+
+      try {
+        if (success) dbWriterAdapter.markSentResilient(inFlight, workerId);
+        else dbWriterAdapter.markRetryResilient(inFlight, workerId);
+      } catch (Exception e) {
+        onDbFail(inFlight, q);
+        log.warn("drainAndUpdate DB failed; requeued {} items", inFlight.size(), e);
+        break;
+      }
+    }
+  }
+
+  private void onDbFail(List<Long> inFlight, BlockingQueue<Long> q) {
+    for (Long id : inFlight) {
+      if (!q.offer(id)) {
+        log.error("requeue overflow: id={}", id);
+      }
+    }
+  }
+
+  @Override
+  @PreDestroy
+  public void close() {
+    flushTick();
+    flushScheduler.shutdown();
+  }
+}

--- a/back/src/main/java/com/rouby/batch/notification/ResultWriter.java
+++ b/back/src/main/java/com/rouby/batch/notification/ResultWriter.java
@@ -1,5 +1,6 @@
 package com.rouby.batch.notification;
 
+import com.rouby.notification.notificationEvent.domain.info.SuccessResult;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import java.util.ArrayList;
@@ -9,6 +10,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +27,7 @@ public class ResultWriter implements AutoCloseable {
 
   @Value("${notification.writer.flush.batch:500}")
   int FLUSH_BATCH_SIZE;
-  @Value("${notification.writer.flush.intervalMs:200}")
+  @Value("${notification.writer.flush.intervalMs:1000}")
   long INTERVAL_MS;
 
   private final CircuitBreakerRegistry cbRegistry;
@@ -33,30 +36,54 @@ public class ResultWriter implements AutoCloseable {
   private final DbWriterAdapter dbWriterAdapter;
 
   private final String workerId = UUID.randomUUID().toString();
-
-  private final BlockingQueue<Long> okQ     = new LinkedBlockingQueue<>(10_000);
-  private final BlockingQueue<Long> failQ   = new LinkedBlockingQueue<>(10_000);
+  private final AtomicBoolean wakeupScheduled = new AtomicBoolean(false);
+  private final BlockingQueue<SuccessResult> okQ = new LinkedBlockingQueue<>(10_000);
+  private final BlockingQueue<Long> failQ = new LinkedBlockingQueue<>(10_000);
 
   public String workerId() { return workerId; }
 
   @PostConstruct
-  void start() {
-    flushScheduler.scheduleAtFixedRate(this::flushTick, INTERVAL_MS, INTERVAL_MS, TimeUnit.MILLISECONDS);
+  public void start() {
+    flushScheduler.scheduleWithFixedDelay(this::flushTick, INTERVAL_MS, INTERVAL_MS, TimeUnit.MILLISECONDS);
+  }
+
+  public void requestFlush() {
+
+    if (wakeupScheduled.compareAndSet(false, true)) {
+      flushScheduler.execute(() -> {
+        try {
+          safeFlushTick();
+        } finally {
+          wakeupScheduled.set(false);
+        }
+      });
+    }
+  }
+
+  private void safeFlushTick() {
+    try {
+      flushTick();
+    } catch (Throwable t) {
+      log.error("flushTick failed", t);
+    }
   }
 
   private void flushTick() {
     CircuitBreaker cb = cbRegistry.circuitBreaker("dbWriter");
 
     if (cb.getState() == CircuitBreaker.State.OPEN) return;
-    drainAndUpdate(okQ,   true);
-
-    if (cb.getState() == CircuitBreaker.State.OPEN) return;
-    drainAndUpdate(failQ, false);
+    drainAndUpdate(okQ,
+        batch -> dbWriterAdapter.markSentResilient(batch, workerId),
+        this::onDbFail);
+    drainAndUpdate(failQ,
+        batch -> dbWriterAdapter.markRetryResilient(batch, workerId),
+        this::onDbFail);
   }
 
-  public void reportSuccess(long id) {
+  public void reportSuccess(long id, long sentAt) {
+
     try {
-      if (!okQ.offer(id)) {
+      if (!okQ.offer(new SuccessResult(id, sentAt))) {
         int size = okQ.size(), rem = okQ.remainingCapacity();
         log.atError()
             .addKeyValue("queue", "okQ")
@@ -77,6 +104,7 @@ public class ResultWriter implements AutoCloseable {
     }
   }
   public void reportFailure(long id) {
+
     try {
       if (!failQ.offer(id)) {
         int size = failQ.size(), rem = failQ.remainingCapacity();
@@ -99,32 +127,37 @@ public class ResultWriter implements AutoCloseable {
     }
   }
 
-  private void drainAndUpdate(BlockingQueue<Long> q, boolean success) {
+  private <E> void drainAndUpdate(BlockingQueue<E> q,
+      ThrowingConsumer<List<E>> process, BiConsumer<List<E>, BlockingQueue<E>> onFail) {
 
     CircuitBreaker cb = cbRegistry.circuitBreaker("dbWriter");
-    int batchSize = (cb.getState() == CircuitBreaker.State.HALF_OPEN)
-        ? Math.min(FLUSH_BATCH_SIZE, 50)
-        : FLUSH_BATCH_SIZE;
 
     while (true) {
-      ArrayList<Long> inFlight = new ArrayList<>(batchSize);
-      q.drainTo(inFlight, batchSize);
+      CircuitBreaker.State state = cb.getState();
+      if (state == CircuitBreaker.State.OPEN) {
+        break;
+      }
+      int batchSize = (state == CircuitBreaker.State.HALF_OPEN)
+          ? Math.min(FLUSH_BATCH_SIZE, 50)
+          : FLUSH_BATCH_SIZE;
 
+      ArrayList<E> inFlight = new ArrayList<>(batchSize);
+      q.drainTo(inFlight, batchSize);
       if (inFlight.isEmpty()) break;
 
       try {
-        if (success) dbWriterAdapter.markSentResilient(inFlight, workerId);
-        else dbWriterAdapter.markRetryResilient(inFlight, workerId);
+        process.accpet(inFlight);
+        if (state == CircuitBreaker.State.HALF_OPEN) break;
       } catch (Exception e) {
-        onDbFail(inFlight, q);
+        onFail.accept(inFlight, q);
         log.warn("drainAndUpdate DB failed; requeued {} items", inFlight.size(), e);
         break;
       }
     }
   }
 
-  private void onDbFail(List<Long> inFlight, BlockingQueue<Long> q) {
-    for (Long id : inFlight) {
+  private <E> void onDbFail(List<E> inFlight, BlockingQueue<E> q) {
+    for (E id : inFlight) {
       if (!q.offer(id)) {
         log.error("requeue overflow: id={}", id);
       }
@@ -134,7 +167,39 @@ public class ResultWriter implements AutoCloseable {
   @Override
   @PreDestroy
   public void close() {
-    flushTick();
+
     flushScheduler.shutdown();
+    boolean terminated = false;
+    try {
+      terminated = flushScheduler.awaitTermination(INTERVAL_MS, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+    }
+
+    final long budgetNanos = TimeUnit.MILLISECONDS.toNanos(500);
+    final long deadline = System.nanoTime() + budgetNanos;
+
+    while ((!(okQ.isEmpty() && failQ.isEmpty())) && System.nanoTime() < deadline) {
+      try {
+        flushTick();
+      } catch (Throwable t) {
+        log.warn("서버 종료를 위한 알림 결과 작성 스케쥴러 정리 중 오류가 발생하였습니다.", t);
+        break;
+      }
+    }
+
+    int okLeft = okQ.size(), failLeft = failQ.size();
+    if (okLeft + failLeft > 0) {
+      log.warn("종료 시 미처리 항목: okQ={}, failQ={}", okLeft, failLeft);
+    }
+
+    if (!terminated) {
+      flushScheduler.shutdownNow();
+    }
+  }
+
+  @FunctionalInterface
+  interface ThrowingConsumer<T> {
+    void accpet(T t) throws Exception;
   }
 }

--- a/back/src/main/java/com/rouby/batch/notification/config/DispatcherThreadConfig.java
+++ b/back/src/main/java/com/rouby/batch/notification/config/DispatcherThreadConfig.java
@@ -14,11 +14,13 @@ public class DispatcherThreadConfig {
   public ThreadPoolTaskExecutor notificationSendExecutor() {
 
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(4);
-    executor.setMaxPoolSize(8);
-    executor.setQueueCapacity(1000);
+    executor.setCorePoolSize(16);
+    executor.setMaxPoolSize(32);
+    executor.setQueueCapacity(200);
     executor.setThreadNamePrefix("notiSendEx-");
     executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.setAwaitTerminationSeconds(30);
     executor.initialize();
     return executor;
   }
@@ -31,7 +33,9 @@ public class DispatcherThreadConfig {
     executor.setMaxPoolSize(8);
     executor.setQueueCapacity(400);
     executor.setThreadNamePrefix("notiCb-");
-    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.setAwaitTerminationSeconds(30);
     executor.initialize();
     return executor;
   }
@@ -39,12 +43,12 @@ public class DispatcherThreadConfig {
   @Bean("preciseTimer")
   public ScheduledExecutorService preciseTimer() {
 
-    return Executors.newScheduledThreadPool(2);
+    return Executors.newScheduledThreadPool(2, r -> new Thread(r, "preciseTimer"));
   }
 
   @Bean("flushScheduler")
   public ScheduledExecutorService flushScheduler() {
 
-    return Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "flush"));
+    return Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "flushScheduler"));
   }
 }

--- a/back/src/main/java/com/rouby/batch/notification/config/DispatcherThreadConfig.java
+++ b/back/src/main/java/com/rouby/batch/notification/config/DispatcherThreadConfig.java
@@ -1,0 +1,50 @@
+package com.rouby.batch.notification.config;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class DispatcherThreadConfig {
+
+  @Bean("notificationSendExecutor")
+  public ThreadPoolTaskExecutor notificationSendExecutor() {
+
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(4);
+    executor.setMaxPoolSize(8);
+    executor.setQueueCapacity(1000);
+    executor.setThreadNamePrefix("notiSendEx-");
+    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+    executor.initialize();
+    return executor;
+  }
+
+  @Bean("resultCallbackExecutor")
+  public ThreadPoolTaskExecutor resultCallbackExecutor() {
+
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(4);
+    executor.setMaxPoolSize(8);
+    executor.setQueueCapacity(400);
+    executor.setThreadNamePrefix("notiCb-");
+    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+    executor.initialize();
+    return executor;
+  }
+
+  @Bean("preciseTimer")
+  public ScheduledExecutorService preciseTimer() {
+
+    return Executors.newScheduledThreadPool(2);
+  }
+
+  @Bean("flushScheduler")
+  public ScheduledExecutorService flushScheduler() {
+
+    return Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "flush"));
+  }
+}

--- a/back/src/main/java/com/rouby/batch/notification/config/DispatcherThreadConfig.java
+++ b/back/src/main/java/com/rouby/batch/notification/config/DispatcherThreadConfig.java
@@ -31,11 +31,10 @@ public class DispatcherThreadConfig {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(4);
     executor.setMaxPoolSize(8);
-    executor.setQueueCapacity(400);
+    executor.setQueueCapacity(1024);
     executor.setThreadNamePrefix("notiCb-");
     executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
-    executor.setWaitForTasksToCompleteOnShutdown(true);
-    executor.setAwaitTerminationSeconds(30);
+    executor.setWaitForTasksToCompleteOnShutdown(false);
     executor.initialize();
     return executor;
   }

--- a/back/src/main/java/com/rouby/common/config/TimeConfig.java
+++ b/back/src/main/java/com/rouby/common/config/TimeConfig.java
@@ -1,0 +1,13 @@
+package com.rouby.common.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+  @Bean
+  public Clock clock() {
+    return Clock.systemUTC();
+  }
+}

--- a/back/src/main/java/com/rouby/common/config/WebClientConfig.java
+++ b/back/src/main/java/com/rouby/common/config/WebClientConfig.java
@@ -1,0 +1,32 @@
+package com.rouby.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+@Configuration
+public class WebClientConfig {
+
+  @Bean
+  WebClient fcmClient() {
+    ConnectionProvider provider = ConnectionProvider.builder("fcm-pool")
+        .maxConnections(400)
+        .pendingAcquireMaxCount(1000)
+        .build();
+
+    var httpClient = HttpClient.create(provider)
+        .protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
+        .secure()
+        .compress(true)
+        .keepAlive(true);
+
+    return WebClient.builder()
+        .clientConnector(new ReactorClientHttpConnector(httpClient))
+        .baseUrl("https://fcm.googleapis.com")
+        .build();
+  }
+}

--- a/back/src/main/java/com/rouby/common/config/WebClientConfig.java
+++ b/back/src/main/java/com/rouby/common/config/WebClientConfig.java
@@ -1,5 +1,8 @@
 package com.rouby.common.config;
 
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -12,21 +15,31 @@ import reactor.netty.resources.ConnectionProvider;
 public class WebClientConfig {
 
   @Bean
-  WebClient fcmClient() {
+  WebClient fcmClient(
+      @Value("${fcm.webClient.base-url:https://fcm.googleapis.com}") String baseUrl,
+      @Value("${fcm.webClient.pool.max-connections:400}") int maxConns,
+      @Value("${fcm.webClient.pool.pending-acquire-max:1000}") int pendingAcquireMax) {
+
     ConnectionProvider provider = ConnectionProvider.builder("fcm-pool")
-        .maxConnections(400)
-        .pendingAcquireMaxCount(1000)
+        .maxConnections(maxConns)
+        .pendingAcquireMaxCount(pendingAcquireMax)
+        .pendingAcquireTimeout(Duration.ofSeconds(10))
+        .maxIdleTime(Duration.ofMinutes(2))
+        .maxLifeTime(Duration.ofMinutes(10))
+        .evictInBackground(Duration.ofSeconds(30))
         .build();
 
-    var httpClient = HttpClient.create(provider)
+    HttpClient httpClient = HttpClient.create(provider)
         .protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
         .secure()
         .compress(true)
-        .keepAlive(true);
+        .keepAlive(true)
+        .responseTimeout(Duration.ofSeconds(10))
+        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000);
 
     return WebClient.builder()
         .clientConnector(new ReactorClientHttpConnector(httpClient))
-        .baseUrl("https://fcm.googleapis.com")
+        .baseUrl(baseUrl)
         .build();
   }
 }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/application/dto/CreateNotificationEventCommand.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/application/dto/CreateNotificationEventCommand.java
@@ -5,6 +5,7 @@ import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationMessage;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationType;
 import com.rouby.notification.notificationEvent.domain.entity.TokenProviderType;
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
 import lombok.Builder;
 
 @Builder
@@ -20,6 +21,17 @@ public record CreateNotificationEventCommand(
 
   public NotificationEvent toEntity() {
     return NotificationEvent.builder()
+        .userId(userId)
+        .deviceTokenInfo(buildDeviceTokenInfo())
+        .message(buildeNotificationMessage())
+        .type(NotificationType.parse(notificationType))
+        .build();
+  }
+
+
+  public NotificationEventInfo toInfo() {
+
+    return NotificationEventInfo.builder()
         .userId(userId)
         .deviceTokenInfo(buildDeviceTokenInfo())
         .message(buildeNotificationMessage())

--- a/back/src/main/java/com/rouby/notification/notificationEvent/application/service/NotificationEventWriteService.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/application/service/NotificationEventWriteService.java
@@ -3,6 +3,7 @@ package com.rouby.notification.notificationEvent.application.service;
 import com.rouby.notification.notificationEvent.application.dto.CreateNotificationEventCommand;
 import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
 import com.rouby.notification.notificationEvent.domain.sender.NotificationSender;
+import java.time.Clock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,11 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class NotificationEventWriteService {
 
+  private final Clock clock = Clock.systemUTC();
   private final NotificationSender notificationSender;
   private final NotificationEventRepository notificationEventRepository;
 
   public void sendNotification(CreateNotificationEventCommand command) {
-    this.notificationSender.send(command.toEntity());
+    this.notificationSender.send(command.toInfo(), 10, clock.millis(), false);
   }
 
   @Transactional

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/entity/NotificationEvent.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/entity/NotificationEvent.java
@@ -11,10 +11,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Entity
 @Getter
@@ -43,15 +45,39 @@ public class NotificationEvent extends LogBaseEntity {
   @Enumerated(EnumType.STRING)
   private SendStatus status;
 
+  @Column(nullable = false)
+  private LocalDateTime dueAt;
+
+  @Column
+  private LocalDateTime retryAt;
+
+  @Column
+  private LocalDateTime sentAt;
+
+  @Column(nullable = false)
+  private Integer attempt;
+
+  @Column
+  private LocalDateTime leaseUntil;
+
+  @Column
+  private String workerId;
+
+  @LastModifiedDate
+  @Column
+  private LocalDateTime updatedAt;
+
   @Builder
   private NotificationEvent(Long userId,
-      DeviceTokenInfo deviceTokenInfo, NotificationMessage message, NotificationType type) {
+      DeviceTokenInfo deviceTokenInfo, NotificationMessage message,
+      NotificationType type, LocalDateTime dueAt) {
 
     this.userId = userId;
     this.deviceTokenInfo = deviceTokenInfo;
     this.message = message;
     this.type = type;
-    this.status = SendStatus.READY;
+    this.status = SendStatus.PENDING;
+    this.dueAt = dueAt;
   }
 
   public void updateMessageUrl(String url) {

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/entity/NotificationType.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/entity/NotificationType.java
@@ -4,6 +4,10 @@ public enum NotificationType {
   SCHEDULE,
   ROUTINE,
   BRIEFING,
+  FEEDBACK,
+  RECOMMENDATION,
+  SCHEDULE_SYNC,
+  ROUTINE_SYNC,
   ;
 
   public static NotificationType parse(String notificationType) {

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/entity/SendStatus.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/entity/SendStatus.java
@@ -1,7 +1,7 @@
 package com.rouby.notification.notificationEvent.domain.entity;
 
 public enum SendStatus {
-  READY,
+  PENDING,
   IN_PROGRESS,
   SENT,
   FAILED

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/info/NotificationEventInfo.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/info/NotificationEventInfo.java
@@ -3,7 +3,7 @@ package com.rouby.notification.notificationEvent.domain.info;
 import com.rouby.notification.notificationEvent.domain.entity.DeviceTokenInfo;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationMessage;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationType;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -13,7 +13,7 @@ public record NotificationEventInfo(
     DeviceTokenInfo deviceTokenInfo,
     NotificationMessage message,
     NotificationType type,
-    Instant dueAt
+    LocalDateTime dueAt
 ) {
 
 }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/info/NotificationEventInfo.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/info/NotificationEventInfo.java
@@ -1,0 +1,19 @@
+package com.rouby.notification.notificationEvent.domain.info;
+
+import com.rouby.notification.notificationEvent.domain.entity.DeviceTokenInfo;
+import com.rouby.notification.notificationEvent.domain.entity.NotificationMessage;
+import com.rouby.notification.notificationEvent.domain.entity.NotificationType;
+import java.time.Instant;
+import lombok.Builder;
+
+@Builder
+public record NotificationEventInfo(
+    Long id,
+    Long userId,
+    DeviceTokenInfo deviceTokenInfo,
+    NotificationMessage message,
+    NotificationType type,
+    Instant dueAt
+) {
+
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/info/SuccessResult.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/info/SuccessResult.java
@@ -1,0 +1,5 @@
+package com.rouby.notification.notificationEvent.domain.info;
+
+public record SuccessResult(long id, long sentAt) {
+
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/repository/NotificationEventRepository.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/repository/NotificationEventRepository.java
@@ -2,8 +2,20 @@ package com.rouby.notification.notificationEvent.domain.repository;
 
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
 import java.util.List;
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
+import java.time.Instant;
 
 public interface NotificationEventRepository {
+
+  List<NotificationEventInfo> claimSlot(Instant slotStart, Instant slotEnd, int limit, String workerId, int leaseSecTime);
+
+  List<NotificationEventInfo> claimBackfill(int minutes, int maxAttempt, int limit, String workerId, int leaseSecTime);
+
+  int markSent(List<Long> ids, String workerId);
+
+  int markRetry(List<Long> ids, String workerId);
+
+  int recoverExpiredLeases();
 
   NotificationEvent save(NotificationEvent entity);
 

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/repository/NotificationEventRepository.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/repository/NotificationEventRepository.java
@@ -1,17 +1,18 @@
 package com.rouby.notification.notificationEvent.domain.repository;
 
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
-import java.util.List;
 import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
+import com.rouby.notification.notificationEvent.domain.info.SuccessResult;
 import java.time.Instant;
+import java.util.List;
 
 public interface NotificationEventRepository {
 
-  List<NotificationEventInfo> claimSlot(Instant slotStart, Instant slotEnd, int limit, String workerId, int leaseSecTime);
+  List<NotificationEventInfo> claimSlot(Instant slotStart, Instant slotEnd, int limit, String workerId, int leaseSeconds);
 
-  List<NotificationEventInfo> claimBackfill(int minutes, int maxAttempt, int limit, String workerId, int leaseSecTime);
+  List<NotificationEventInfo> claimBackfill(int minutes, int maxAttempt, int limit, String workerId, int leaseSeconds);
 
-  int markSent(List<Long> ids, String workerId);
+  int markSent(List<SuccessResult> ids, String workerId);
 
   int markRetry(List<Long> ids, String workerId);
 

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/sender/AsyncNotificationSender.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/sender/AsyncNotificationSender.java
@@ -1,0 +1,10 @@
+package com.rouby.notification.notificationEvent.domain.sender;
+
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
+import java.util.concurrent.CompletableFuture;
+
+public interface AsyncNotificationSender {
+
+  CompletableFuture<Boolean> sendAsync(
+      NotificationEventInfo ev, int ttlSec, long sentAt, boolean highPriority);
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/domain/sender/NotificationSender.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/domain/sender/NotificationSender.java
@@ -1,8 +1,8 @@
 package com.rouby.notification.notificationEvent.domain.sender;
 
-import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
 
 public interface NotificationSender {
 
-  void send(NotificationEvent event);
+  boolean send(NotificationEventInfo eventInfo, int ttl, long sentAt, boolean highPriority);
 }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/exception/NotificationEventFcmException.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/exception/NotificationEventFcmException.java
@@ -1,0 +1,16 @@
+package com.rouby.notification.notificationEvent.infrastructure.exception;
+
+import com.rouby.common.exception.CustomException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NotificationEventFcmException extends CustomException {
+
+  public NotificationEventFcmException(HttpStatus status, String msg) {
+    super(status, msg);
+  }
+  public HttpStatus status() {
+    return super.getStatus();
+  }
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/exception/NotificationEventFcmRetryableException.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/exception/NotificationEventFcmRetryableException.java
@@ -1,0 +1,19 @@
+package com.rouby.notification.notificationEvent.infrastructure.exception;
+
+import com.rouby.common.exception.CustomException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NotificationEventFcmRetryableException extends CustomException {
+
+  private final String retryAfter;
+
+  public NotificationEventFcmRetryableException(HttpStatus status, String msg, String retryAfter) {
+    super(status, msg);
+    this.retryAfter = retryAfter;
+  }
+  public HttpStatus status() {
+    return super.getStatus();
+  }
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmConfiguration.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmConfiguration.java
@@ -25,6 +25,16 @@ public class FcmConfiguration {
   }
 
   @Bean
+  GoogleCredentials fcmGoogleCredentials() throws IOException {
+
+    ClassPathResource resource = new ClassPathResource(FIREBASE_KEY_PATH);
+    InputStream serviceAccount  = resource.getInputStream();
+
+    return GoogleCredentials.fromStream(serviceAccount)
+        .createScoped(List.of("https://www.googleapis.com/auth/firebase.messaging"));
+  }
+
+  @Bean
   FirebaseMessaging firebaseMessaging() {
 
     try {
@@ -38,11 +48,9 @@ public class FcmConfiguration {
           }
         }
       } else {
-        ClassPathResource resource = new ClassPathResource(FIREBASE_KEY_PATH);
-        InputStream serviceAccount  = resource.getInputStream();
 
         FirebaseOptions options = FirebaseOptions.builder()
-            .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+            .setCredentials(fcmGoogleCredentials())
             .build();
         firebaseApp = FirebaseApp.initializeApp(options);
       }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmConfiguration.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmConfiguration.java
@@ -28,10 +28,10 @@ public class FcmConfiguration {
   GoogleCredentials fcmGoogleCredentials() throws IOException {
 
     ClassPathResource resource = new ClassPathResource(FIREBASE_KEY_PATH);
-    InputStream serviceAccount  = resource.getInputStream();
-
-    return GoogleCredentials.fromStream(serviceAccount)
-        .createScoped(List.of("https://www.googleapis.com/auth/firebase.messaging"));
+    try (InputStream serviceAccount = resource.getInputStream()) {
+      return GoogleCredentials.fromStream(serviceAccount)
+          .createScoped(List.of("https://www.googleapis.com/auth/firebase.messaging"));
+    }
   }
 
   @Bean

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmMessageHelper.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmMessageHelper.java
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.WebpushNotification;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
 import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -36,7 +37,7 @@ public class FcmMessageHelper {
     // 공통 data
     Map<String, String> data = new HashMap<>();
     data.put("eventId", String.valueOf(event.id()));
-    data.put("dueAt", String.valueOf(event.dueAt().toEpochMilli()));
+    data.put("dueAt", String.valueOf(event.dueAt().atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli()));
     data.put("sentAt", String.valueOf(sentAtMs));
     data.put("priority", highPriority ? "high" : "normal");
 
@@ -89,7 +90,7 @@ public class FcmMessageHelper {
     return Message.builder()
         .setToken(event.deviceTokenInfo().getDeviceToken())
         .putData("eventId", String.valueOf(event.id()))
-        .putData("dueAt", String.valueOf(event.dueAt().toEpochMilli()))
+        .putData("dueAt", String.valueOf(event.dueAt().atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli()))
         .putData("sentAt", String.valueOf(sentAt))
         .putData("title", Objects.toString(event.message().getTitle(), ""))
         .putData("body",  Objects.toString(event.message().getBody(), ""))

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmMessageHelper.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmMessageHelper.java
@@ -6,7 +6,10 @@ import com.google.firebase.messaging.WebpushConfig;
 import com.google.firebase.messaging.WebpushFcmOptions;
 import com.google.firebase.messaging.WebpushNotification;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -27,24 +30,81 @@ public class FcmMessageHelper {
     this.iconUri = iconUri;
   }
 
-  public Message buildCustomMessage(NotificationEvent event) {
+  public Map<String, Object> buildFcmHttpV1Payload(NotificationEventInfo event,
+      int ttlSec, long sentAtMs, boolean highPriority) {
+
+    // 공통 data
+    Map<String, String> data = new HashMap<>();
+    data.put("eventId", String.valueOf(event.id()));
+    data.put("dueAt", String.valueOf(event.dueAt().toEpochMilli()));
+    data.put("sentAt", String.valueOf(sentAtMs));
+    data.put("priority", highPriority ? "high" : "normal");
+
+    // WebPush 설정 (브라우저용)
+    Map<String, Object> webpushHeaders = new HashMap<>();
+    webpushHeaders.put("TTL", String.valueOf(ttlSec));
+    webpushHeaders.put("Urgency", highPriority ? "high" : "normal");  // very-low/low/normal/high
+    // webpushHeaders.put("Topic", "event-" + ev.id()); // (선택) 중복 억제
+
+    Map<String, Object> webpushNotif = Map.of(
+        "title", event.message().getTitle(),
+        "body", event.message().getBody(),
+        "tag", "event-" + event.id(), // 브라우저 측 대체 키
+        "icon",  (iconUri.startsWith("http")
+            ? iconUri
+            : appUrl + (iconUri.startsWith("/") ? iconUri : ("/" + iconUri)))
+    );
+
+    Map<String, Object> webpush = new HashMap<>();
+    webpush.put("headers", webpushHeaders);
+    webpush.put("notification", webpushNotif);
+    webpush.put("fcm_options", Map.of("link", event.message().getUrl()));
+
+    // Android 설정
+    Map<String, Object> android = new HashMap<>();
+    android.put("priority", highPriority ? "HIGH" : "NORMAL"); // HIGH/NORMAL
+    android.put("ttl", ttlSec + "s");                          // "60s" 형식
+    // android.put("collapse_key", "event-" + ev.id());        // (선택) 안드 대체 키
+
+    // APNs(iOS) 설정 (웹푸시가 아닌 네이티브 iOS 앱 쓰는 경우에만)
+    long expirationEpochSec = (sentAtMs + ttlSec * 1000L) / 1000L;
+    Map<String, String> apnsHeaders = new HashMap<>();
+    apnsHeaders.put("apns-priority", highPriority ? "10" : "5"); // 10=즉시, 5=배경
+    apnsHeaders.put("apns-expiration", String.valueOf(expirationEpochSec));
+    Map<String, Object> apns = Map.of("headers", apnsHeaders);
+
+    // 최종 message
+    Map<String, Object> message = new HashMap<>();
+    message.put("token", event.deviceTokenInfo().getDeviceToken());
+    message.put("data", data);
+    message.put("webpush", webpush);   // 웹 대상일 때 유효
+    message.put("android", android);   // 안드로이드 앱 대상일 때 유효
+    message.put("apns", apns);         // iOS 앱 대상일 때 유효
+
+    return Map.of("message", message);
+  }
+
+  public Message buildCustomMessage(NotificationEventInfo event, int ttl, long sentAt, boolean highPriority) {
 
     return Message.builder()
-        .setToken(event.getDeviceTokenInfo().getDeviceToken())
-        .putData("title", Objects.toString(event.getMessage().getTitle(), ""))
-        .putData("body",  Objects.toString(event.getMessage().getBody(), ""))
+        .setToken(event.deviceTokenInfo().getDeviceToken())
+        .putData("eventId", String.valueOf(event.id()))
+        .putData("dueAt", String.valueOf(event.dueAt().toEpochMilli()))
+        .putData("sentAt", String.valueOf(sentAt))
+        .putData("title", Objects.toString(event.message().getTitle(), ""))
+        .putData("body",  Objects.toString(event.message().getBody(), ""))
         .putData("icon",  (iconUri.startsWith("http")
             ? iconUri
             : appUrl + (iconUri.startsWith("/") ? iconUri : ("/" + iconUri))))
-        .putData("url",   Objects.toString(event.getMessage().getUrl(), ""))
-        .setWebpushConfig(buildWebpushConfig())
+        .putData("url",   Objects.toString(event.message().getUrl(), ""))
+        .setWebpushConfig(buildWebpushConfig(ttl))
         .build();
   }
 
-  public Message buildBasicNotificationMessage(NotificationEvent event) {
+  public Message buildBasicNotificationMessage(NotificationEvent event, int ttl) {
 
     Notification notification = buildNotification(event);
-    WebpushConfig webpushConfig = buildWebpushConfig(event);
+    WebpushConfig webpushConfig = buildWebpushConfig(event, ttl);
 
     return Message.builder()
         .setToken(event.getDeviceTokenInfo().getDeviceToken())
@@ -53,16 +113,16 @@ public class FcmMessageHelper {
         .build();
   }
 
-  private WebpushConfig buildWebpushConfig() {
+  private WebpushConfig buildWebpushConfig(int ttl) {
     return WebpushConfig.builder()
-        .putHeader("TTL", TTL_SECONDS)
+        .putHeader("TTL", String.valueOf(ttl))
         .build();
   }
 
-  private WebpushConfig buildWebpushConfig(NotificationEvent event) {
+  private WebpushConfig buildWebpushConfig(NotificationEvent event, int ttl) {
     return WebpushConfig.builder()
         .setNotification(buildWebpushNotification(event))
-        .putHeader("TTL", TTL_SECONDS)
+        .putHeader("TTL", String.valueOf(ttl))
         .setFcmOptions(buildFcmOptions(event))
         .build();
   }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmSender.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/FcmSender.java
@@ -4,8 +4,8 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.rouby.common.exception.type.ApiErrorCode;
-import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
 import com.rouby.notification.notificationEvent.domain.sender.NotificationSender;
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
 import com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventInfraException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,18 +14,18 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class FirebaseNotificationSender implements NotificationSender {
+public class FcmSender implements NotificationSender {
 
   private final FirebaseMessaging firebaseMessaging;
   private final FcmMessageHelper fcmMessageHelper;
 
   @Override
-  public void send(NotificationEvent event) {
+  public boolean send(NotificationEventInfo event, int ttl, long sentAt, boolean highPriority) {
 
-    Message message = fcmMessageHelper.buildCustomMessage(event);
-
+    Message message = fcmMessageHelper.buildCustomMessage(event, ttl, sentAt, highPriority);
     try {
       firebaseMessaging.send(message);
+      return true;
     } catch (FirebaseMessagingException e) {
       log.error("firebase 알림 전송 실패: {}", e.getMessage(), e);
       throw NotificationEventInfraException.from(ApiErrorCode.INTERNAL_SERVER_ERROR);

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/GoogleAccessTokenProvider.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/GoogleAccessTokenProvider.java
@@ -2,12 +2,12 @@ package com.rouby.notification.notificationEvent.infrastructure.messaging.fcm;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -24,7 +24,7 @@ public class GoogleAccessTokenProvider {
   @PostConstruct
   void prewarm() throws IOException {
 
-    fcmGoogleCredentials.refreshIfExpired();
+    fcmGoogleCredentials.refresh();
     AccessToken t = fcmGoogleCredentials.getAccessToken();
     if (t != null) tokenRef.set(t);
   }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/GoogleAccessTokenProvider.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/GoogleAccessTokenProvider.java
@@ -1,0 +1,73 @@
+package com.rouby.notification.notificationEvent.infrastructure.messaging.fcm;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleAccessTokenProvider {
+
+  private static final long SKEW_MS = Duration.ofMinutes(2).toMillis(); // 만료 2분 전 갱신
+
+  private final GoogleCredentials fcmGoogleCredentials;
+  private final AtomicReference<AccessToken> tokenRef = new AtomicReference<>();
+  private final AtomicBoolean refreshing = new AtomicBoolean(false);
+
+  @PostConstruct
+  void prewarm() throws IOException {
+
+    fcmGoogleCredentials.refreshIfExpired();
+    AccessToken t = fcmGoogleCredentials.getAccessToken();
+    if (t != null) tokenRef.set(t);
+  }
+
+  public String fetchAccessToken() {
+
+    AccessToken cur = tokenRef.get();
+    if (cur != null && !isExpiringSoon(cur)) {
+      return cur.getTokenValue();
+    }
+
+    if (refreshing.compareAndSet(false, true)) {
+      try {
+        fcmGoogleCredentials.refresh();
+        AccessToken fresh = fcmGoogleCredentials.getAccessToken();
+
+        if (fresh == null)
+          throw new IllegalStateException("AccessToken이 리프레시 수행 후 null 값으로 확인되었습니다.");
+
+        tokenRef.set(fresh);
+        return fresh.getTokenValue();
+      } catch (IOException e) {
+
+        AccessToken fallback = tokenRef.get();
+        if (fallback != null && !isExpiringSoon(fallback))
+          return fallback.getTokenValue();
+        throw new RuntimeException("FCM을 위한 Google AccessToken의 갱신을 실패하였습니다.", e);
+      } finally {
+        refreshing.set(false);
+      }
+    }
+
+    AccessToken t = tokenRef.get();
+    if (t != null) return t.getTokenValue();
+
+    throw new IllegalStateException("FCM을 위한 Google AccessToken이 사용 가능하지 않습니다. (현재 리프레시 동작 중)");
+  }
+
+  private boolean isExpiringSoon(AccessToken t) {
+
+    Date exp = t.getExpirationTime();
+    if (exp == null) return true;
+    long remain = exp.getTime() - System.currentTimeMillis();
+    return remain <= SKEW_MS;
+  }
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/WebClientFcmSender.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/WebClientFcmSender.java
@@ -1,0 +1,39 @@
+package com.rouby.notification.notificationEvent.infrastructure.messaging.fcm;
+
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
+import com.rouby.notification.notificationEvent.domain.sender.AsyncNotificationSender;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+
+@Component
+@RequiredArgsConstructor
+public class WebClientFcmSender implements AsyncNotificationSender {
+
+  private final String projectId = "rouby-b3e76";
+  private final WebClient fcmClient;
+  private final GoogleAccessTokenProvider tokenProvider;
+  private final FcmMessageHelper messageHelper;
+
+  @Override
+  public CompletableFuture<Boolean> sendAsync(
+      NotificationEventInfo event, int ttlSec, long sentAt, boolean highPriority) {
+
+    Map<String, Object> payload = messageHelper.buildFcmHttpV1Payload(event, ttlSec, sentAt, highPriority);
+
+    return fcmClient.post()
+        .uri("/v1/projects/{pid}/messages:send", projectId)
+        .headers(h -> h.setBearerAuth(tokenProvider.fetchAccessToken()))
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(payload)
+        .exchangeToMono(resp -> Mono.just(resp.statusCode().is2xxSuccessful()))
+        .toFuture();
+  }
+
+
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/WebClientFcmSender.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/WebClientFcmSender.java
@@ -2,12 +2,15 @@ package com.rouby.notification.notificationEvent.infrastructure.messaging.fcm;
 
 import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
 import com.rouby.notification.notificationEvent.domain.sender.AsyncNotificationSender;
+import com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventFcmException;
+import com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventFcmRetryableException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -37,12 +40,22 @@ public class WebClientFcmSender implements AsyncNotificationSender {
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(payload)
         .retrieve()
-        .onStatus(HttpStatusCode::isError, resp ->
-            resp.bodyToMono(String.class)
-                .defaultIfEmpty("")
-                .map(body -> new FcmHttpException(
-                    resp.statusCode().value(),
-                    "FCM HTTP error: " + resp.statusCode() + " body=" + body))
+        .onStatus(HttpStatusCode::isError, resp -> resp.bodyToMono(String.class)
+              .defaultIfEmpty("")
+              .map(body -> {
+
+                if (resp.statusCode().is4xxClientError() && resp.statusCode().value() != 429) {
+                  return new NotificationEventFcmException(
+                      (HttpStatus) resp.statusCode(),
+                      "FCM WebClient error: " + resp.statusCode() + " body=" + body);
+                }
+
+                String retryAfter = resp.headers().asHttpHeaders().getFirst("Retry-After");
+                return new NotificationEventFcmRetryableException(
+                    (HttpStatus) resp.statusCode(),
+                    "FCM WebClient error: " + resp.statusCode() + " body=" + body,
+                    retryAfter);
+              })
         )
         .bodyToMono(Void.class)
         .thenReturn(true)
@@ -52,12 +65,5 @@ public class WebClientFcmSender implements AsyncNotificationSender {
           log.warn("FCM 호출 실패 type={}, root={}", t.getClass().getName(), root.getClass().getName(), t);
         })
         .toFuture();
-  }
-
-  // 예시 커스텀 예외들
-  public static class FcmHttpException extends RuntimeException {
-    private final int status;
-    public FcmHttpException(int status, String msg) { super(msg); this.status = status; }
-    public int status() { return status; }
   }
 }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/WebClientFcmSender.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/messaging/fcm/WebClientFcmSender.java
@@ -2,20 +2,25 @@ package com.rouby.notification.notificationEvent.infrastructure.messaging.fcm;
 
 import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
 import com.rouby.notification.notificationEvent.domain.sender.AsyncNotificationSender;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
+import reactor.core.Exceptions;
 
-
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WebClientFcmSender implements AsyncNotificationSender {
 
-  private final String projectId = "rouby-b3e76";
+  @Value("${fcm.projectId}")
+  private String projectId;;
   private final WebClient fcmClient;
   private final GoogleAccessTokenProvider tokenProvider;
   private final FcmMessageHelper messageHelper;
@@ -31,9 +36,28 @@ public class WebClientFcmSender implements AsyncNotificationSender {
         .headers(h -> h.setBearerAuth(tokenProvider.fetchAccessToken()))
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(payload)
-        .exchangeToMono(resp -> Mono.just(resp.statusCode().is2xxSuccessful()))
+        .retrieve()
+        .onStatus(HttpStatusCode::isError, resp ->
+            resp.bodyToMono(String.class)
+                .defaultIfEmpty("")
+                .map(body -> new FcmHttpException(
+                    resp.statusCode().value(),
+                    "FCM HTTP error: " + resp.statusCode() + " body=" + body))
+        )
+        .bodyToMono(Void.class)
+        .thenReturn(true)
+        .timeout(Duration.ofSeconds(10))
+        .doOnError(t -> {
+          Throwable root = Exceptions.unwrap(t);
+          log.warn("FCM 호출 실패 type={}, root={}", t.getClass().getName(), root.getClass().getName(), t);
+        })
         .toFuture();
   }
 
-
+  // 예시 커스텀 예외들
+  public static class FcmHttpException extends RuntimeException {
+    private final int status;
+    public FcmHttpException(int status, String msg) { super(msg); this.status = status; }
+    public int status() { return status; }
+  }
 }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/NotificationEventRepositoryImpl.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/NotificationEventRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.rouby.notification.notificationEvent.infrastructure.persistence;
+
+import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
+import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
+import com.rouby.notification.notificationEvent.infrastructure.persistence.jdbc.NotificationEventJdbcRepository;
+import com.rouby.notification.notificationEvent.infrastructure.persistence.jpa.NotificationEventJpaRepository;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class NotificationEventRepositoryImpl implements NotificationEventRepository {
+
+  private final NotificationEventJpaRepository jpaRepository;
+  private final NotificationEventJdbcRepository jdbcRepository;
+
+
+  @Override
+  public List<NotificationEventInfo> claimSlot(Instant slotStart, Instant slotEnd, int limit, String workerId, int leaseSecTime) {
+    return jdbcRepository.claimSlot(slotStart, slotEnd, limit, workerId, leaseSecTime);
+  }
+
+  @Override
+  public List<NotificationEventInfo> claimBackfill(
+      int minutes, int maxAttempt, int limit, String workerId, int leaseSecTime) {
+    return jdbcRepository.claimBackfill(minutes, maxAttempt, limit, workerId, leaseSecTime);
+  }
+
+  @Override
+  public int markSent(List<Long> ids, String workerId) {
+    return jdbcRepository.markSent(ids, workerId);
+  }
+
+  @Override
+  public int markRetry(List<Long> ids, String workerId) {
+    return jdbcRepository.markRetry(ids, workerId);
+  }
+
+  @Override
+  public int recoverExpiredLeases() {
+    return jdbcRepository.recoverExpiredLeases();
+  }
+
+  @Override
+  public NotificationEvent save(NotificationEvent entity) {
+    return jpaRepository.save(entity);
+  }
+
+  @Override
+  public <S extends NotificationEvent> List<S> saveAll(Iterable<S> entities) {
+    return jpaRepository.saveAll(entities);
+  }
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/NotificationEventRepositoryImpl.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/NotificationEventRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.rouby.notification.notificationEvent.infrastructure.persistence;
 
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
+import com.rouby.notification.notificationEvent.domain.info.SuccessResult;
 import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
 import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
 import com.rouby.notification.notificationEvent.infrastructure.persistence.jdbc.NotificationEventJdbcRepository;
@@ -30,8 +31,8 @@ public class NotificationEventRepositoryImpl implements NotificationEventReposit
   }
 
   @Override
-  public int markSent(List<Long> ids, String workerId) {
-    return jdbcRepository.markSent(ids, workerId);
+  public int markSent(List<SuccessResult> successResults, String workerId) {
+    return jdbcRepository.markSent(successResults, workerId);
   }
 
   @Override

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/jdbc/NotificationEventJdbcRepository.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/jdbc/NotificationEventJdbcRepository.java
@@ -4,15 +4,17 @@ import com.rouby.notification.notificationEvent.domain.entity.DeviceTokenInfo;
 import com.rouby.notification.notificationEvent.domain.entity.NotificationMessage;
 import com.rouby.notification.notificationEvent.domain.entity.TokenProviderType;
 import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
+import com.rouby.notification.notificationEvent.domain.info.SuccessResult;
+import java.sql.Array;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -22,9 +24,7 @@ public class NotificationEventJdbcRepository {
 
   private final JdbcTemplate jdbcTemplate;
 
-
-
-  public List<NotificationEventInfo> claimSlot(Instant slotStart, Instant slotEnd, int limit, String workerId, int leaseSecTime) {
+  public List<NotificationEventInfo> claimSlot(Instant slotStart, Instant slotEnd, int limit, String workerId, int leaseSeconds) {
 
     final String sql = """
       with picked as (
@@ -53,12 +53,12 @@ public class NotificationEventJdbcRepository {
         Timestamp.from(slotStart),
         Timestamp.from(slotEnd),
         limit,
-        leaseSecTime,
+        leaseSeconds,
         workerId);
   }
 
   public List<NotificationEventInfo> claimBackfill(
-      int minutes, int maxAttempt, int limit, String workerId, int leaseSecTime) {
+      int minutes, int maxAttempt, int limit, String workerId, int leaseSeconds) {
 
     final String sql = """
       with picked as (
@@ -83,22 +83,48 @@ public class NotificationEventJdbcRepository {
       where e.id = picked.id
       returning e.id, e.user_id, e.due_at, e.title, e.body, e.url, e.device_token, e.token_provider
     """;
+
     return jdbcTemplate.query(sql,
-        (rs,i) ->
-            map(rs), minutes, maxAttempt, limit, leaseSecTime, workerId);
+        (rs,i) -> map(rs),
+        minutes,
+        maxAttempt,
+        limit,
+        leaseSeconds,
+        workerId);
   }
 
-  public int markSent(List<Long> ids, String workerId) {
+  public int markSent(List<SuccessResult> successResults, String workerId) {
 
-    if (ids.isEmpty()) return 0;
+    if (successResults.isEmpty()) return 0;
 
     final String sql = """
-      update notification_event e
-      set status='SENT', lease_until=null, updated_at=now()
-      from unnest(?::bigint[]) as t(id)
-      where e.id = t.id and e.status='IN_PROGRESS' and e.worker_id = ?
+      UPDATE notification_event AS e
+      SET
+        status     = 'SENT',
+        lease_until= NULL,
+        sent_at    = t.sent_at,
+        updated_at = now()
+      FROM unnest(?::bigint[], ?::timestamptz[]) AS t(id, sent_at)
+      WHERE e.id = t.id
+        AND e.status   = 'IN_PROGRESS'
+        AND e.worker_id = ?;
     """;
-    return jdbcTemplate.update(sql, toSqlArray(ids), workerId);
+
+    Long[] ids = successResults.stream()
+        .map(r -> r.id())
+        .toArray(Long[]::new);
+    Timestamp[] sentAts = successResults.stream()
+        .map(r -> Timestamp.from(Instant.ofEpochMilli(r.sentAt())))
+        .toArray(Timestamp[]::new);
+
+    return jdbcTemplate.execute((Connection con) -> {
+      try (PreparedStatement ps = con.prepareStatement(sql)) {
+        ps.setArray(1, con.createArrayOf("bigint", ids));
+        ps.setArray(2, con.createArrayOf("timestamptz", sentAts));
+        ps.setString(3, workerId);
+        return ps.executeUpdate();
+      }
+    });
   }
 
   public int markRetry(List<Long> ids, String workerId) {
@@ -114,15 +140,21 @@ public class NotificationEventJdbcRepository {
       from unnest(?::bigint[]) as t(id)
       where e.id = t.id and e.status='IN_PROGRESS' and e.worker_id = ?
     """;
-    return jdbcTemplate.update(sql, toSqlArray(ids), workerId);
+    return executeSqlWithArray(sql, ids, workerId);
   }
 
   public int recoverExpiredLeases() {
 
     final String sql = """
       update notification_event
-      set status='PENDING', lease_until=null, worker_id=null, updated_at=now()
-      where status='IN_PROGRESS' and lease_until < now()
+      set 
+          status='PENDING', 
+          lease_until=null, 
+          worker_id=null, 
+          updated_at=now()
+      where 
+          status='IN_PROGRESS' 
+        and lease_until < now()
     """;
     return jdbcTemplate.update(sql);
   }
@@ -132,7 +164,7 @@ public class NotificationEventJdbcRepository {
     return NotificationEventInfo.builder()
         .id(rs.getLong("id"))
         .userId(rs.getLong("user_id"))
-        .dueAt(rs.getTimestamp("due_at").toInstant())
+        .dueAt(rs.getTimestamp("due_at").toLocalDateTime())
         .message(NotificationMessage.builder()
             .title(rs.getString("title"))
             .body(rs.getString("body"))
@@ -145,12 +177,18 @@ public class NotificationEventJdbcRepository {
         .build();
   }
 
-  private java.sql.Array toSqlArray(List<Long> ids) {
+  private int executeSqlWithArray(String sql, List<Long> ids, String workerId) {
 
-    try (Connection conn = Objects.requireNonNull(jdbcTemplate.getDataSource()).getConnection()) {
-      return conn.createArrayOf("bigint", ids.toArray());
-    } catch (SQLException e) {
-      throw new DataAccessResourceFailureException("array", e);
-    }
+    return jdbcTemplate.execute((ConnectionCallback<Integer>) con -> {
+      Array array = con.createArrayOf("bigint", ids.toArray());
+
+      try (PreparedStatement ps = con.prepareStatement(sql)) {
+        ps.setArray(1, array);
+        ps.setString(2, workerId);
+        return ps.executeUpdate();
+      } finally {
+        array.free();
+      }
+    });
   }
 }

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/jdbc/NotificationEventJdbcRepository.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/jdbc/NotificationEventJdbcRepository.java
@@ -1,0 +1,156 @@
+package com.rouby.notification.notificationEvent.infrastructure.persistence.jdbc;
+
+import com.rouby.notification.notificationEvent.domain.entity.DeviceTokenInfo;
+import com.rouby.notification.notificationEvent.domain.entity.NotificationMessage;
+import com.rouby.notification.notificationEvent.domain.entity.TokenProviderType;
+import com.rouby.notification.notificationEvent.domain.info.NotificationEventInfo;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationEventJdbcRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+
+
+
+  public List<NotificationEventInfo> claimSlot(Instant slotStart, Instant slotEnd, int limit, String workerId, int leaseSecTime) {
+
+    final String sql = """
+      with picked as (
+        select id
+        from notification_event
+        where status = 'PENDING'
+          and due_at >= ?::timestamptz
+          and due_at <  ?::timestamptz
+        order by due_at
+        for update skip locked
+        limit ?
+      )
+      update notification_event e
+      set status      = 'IN_PROGRESS',
+          lease_until = e.due_at + make_interval(secs => ?),
+          worker_id   = ?,
+          attempt     = coalesce(e.attempt, 0) + 1,
+          updated_at  = now()
+      from picked
+      where e.id = picked.id
+      returning e.id, e.user_id, e.due_at, e.title, e.body, e.url, e.device_token, e.token_provider
+      """;
+
+    return jdbcTemplate.query(sql,
+        (rs,i) -> map(rs),
+        Timestamp.from(slotStart),
+        Timestamp.from(slotEnd),
+        limit,
+        leaseSecTime,
+        workerId);
+  }
+
+  public List<NotificationEventInfo> claimBackfill(
+      int minutes, int maxAttempt, int limit, String workerId, int leaseSecTime) {
+
+    final String sql = """
+      with picked as (
+        select id
+        from notification_event
+        where status='PENDING'
+          and due_at <= now()
+          and due_at >= now() - make_interval(mins => ?)
+          and (retry_at IS NULL OR retry_at <= now())
+          and attempt < ?
+        order by due_at
+        for update skip locked
+        limit ?
+      )
+      update notification_event e
+      set status='IN_PROGRESS',
+          lease_until = now() + make_interval(secs => ?),
+          worker_id   = ?,
+          attempt     = e.attempt + 1,
+          updated_at  = now()
+      from picked
+      where e.id = picked.id
+      returning e.id, e.user_id, e.due_at, e.title, e.body, e.url, e.device_token, e.token_provider
+    """;
+    return jdbcTemplate.query(sql,
+        (rs,i) ->
+            map(rs), minutes, maxAttempt, limit, leaseSecTime, workerId);
+  }
+
+  public int markSent(List<Long> ids, String workerId) {
+
+    if (ids.isEmpty()) return 0;
+
+    final String sql = """
+      update notification_event e
+      set status='SENT', lease_until=null, updated_at=now()
+      from unnest(?::bigint[]) as t(id)
+      where e.id = t.id and e.status='IN_PROGRESS' and e.worker_id = ?
+    """;
+    return jdbcTemplate.update(sql, toSqlArray(ids), workerId);
+  }
+
+  public int markRetry(List<Long> ids, String workerId) {
+
+    if (ids.isEmpty()) return 0;
+
+    final String sql = """
+      update notification_event e
+      set status='PENDING',
+          retry_at = now() + make_interval(secs => LEAST(300, 5 * cast(power(2, greatest(0, e.attempt-1)) as int))),
+          lease_until=null,
+          updated_at=now()
+      from unnest(?::bigint[]) as t(id)
+      where e.id = t.id and e.status='IN_PROGRESS' and e.worker_id = ?
+    """;
+    return jdbcTemplate.update(sql, toSqlArray(ids), workerId);
+  }
+
+  public int recoverExpiredLeases() {
+
+    final String sql = """
+      update notification_event
+      set status='PENDING', lease_until=null, worker_id=null, updated_at=now()
+      where status='IN_PROGRESS' and lease_until < now()
+    """;
+    return jdbcTemplate.update(sql);
+  }
+
+  private NotificationEventInfo map(ResultSet rs) throws SQLException {
+
+    return NotificationEventInfo.builder()
+        .id(rs.getLong("id"))
+        .userId(rs.getLong("user_id"))
+        .dueAt(rs.getTimestamp("due_at").toInstant())
+        .message(NotificationMessage.builder()
+            .title(rs.getString("title"))
+            .body(rs.getString("body"))
+            .url(rs.getString("url"))
+            .build())
+        .deviceTokenInfo(DeviceTokenInfo.builder()
+            .tokenProvider(TokenProviderType.parse(rs.getString("token_provider")))
+            .deviceToken(rs.getString("device_token"))
+            .build())
+        .build();
+  }
+
+  private java.sql.Array toSqlArray(List<Long> ids) {
+
+    try (Connection conn = Objects.requireNonNull(jdbcTemplate.getDataSource()).getConnection()) {
+      return conn.createArrayOf("bigint", ids.toArray());
+    } catch (SQLException e) {
+      throw new DataAccessResourceFailureException("array", e);
+    }
+  }
+}

--- a/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/jpa/NotificationEventJpaRepository.java
+++ b/back/src/main/java/com/rouby/notification/notificationEvent/infrastructure/persistence/jpa/NotificationEventJpaRepository.java
@@ -1,11 +1,9 @@
 package com.rouby.notification.notificationEvent.infrastructure.persistence.jpa;
 
 import com.rouby.notification.notificationEvent.domain.entity.NotificationEvent;
-import com.rouby.notification.notificationEvent.domain.repository.NotificationEventRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationEventJpaRepository extends
-    JpaRepository<NotificationEvent, Long>, NotificationEventRepository,
-    NotificationEventJpaRepositoryCustom {
+    JpaRepository<NotificationEvent, Long>, NotificationEventJpaRepositoryCustom {
 
 }

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -19,6 +19,8 @@ spring:
       - classpath:properties/quartz.yml
       - classpath:properties/batch.yml
       - classpath:properties/schedule.yml
+      - classpath:properties/notification-worker.yml
+      - classpath:properties/resilience.yml
   profiles:
     group:
       local: local

--- a/back/src/main/resources/db/schema.sql
+++ b/back/src/main/resources/db/schema.sql
@@ -17,3 +17,8 @@ CREATE INDEX IF NOT EXISTS idx_rt_child_parent_active
 CREATE INDEX IF NOT EXISTS idx_daily_tasks_task_rid_date_cover
     ON daily_tasks(routine_task_id, task_date)
     INCLUDE (current_value);
+
+-- NOTIFICATION_EVENT
+CREATE INDEX IF NOT EXISTS idx_ne_inprog_lease_until
+    ON notification_event (lease_until)
+    WHERE status='IN_PROGRESS';

--- a/back/src/main/resources/properties/firebase.yml
+++ b/back/src/main/resources/properties/firebase.yml
@@ -1,2 +1,8 @@
 fcm:
   key_file_path: "firebase/rouby-firebase-adminsdk-key.json"
+  projectId: rouby-b3e76
+  webClient:
+    base-url: https://fcm.googleapis.com
+    pool:
+      max-connections: 400
+      pending-acquire-max: 1000

--- a/back/src/main/resources/properties/notification-worker.yml
+++ b/back/src/main/resources/properties/notification-worker.yml
@@ -2,6 +2,7 @@ spring:
   config.activate.on-profile: local
 notification:
   dispatch:
+    maxConcurrent: 512
     limit: 200
     maxAttempt: 3
     timeBudgetSec: 50
@@ -12,18 +13,19 @@ notification:
       ontimeSec: 60
       backfillSec: 600
     lease:
-      ontimeSec: 60
+      ontimeSec: 45
       backfillSec: 30
   writer:
     flush:
       batch: 500
-      intervalMs: 200
+      intervalMs: 1000
 
 ---
 spring:
   config.activate.on-profile: test
 notification:
   dispatch:
+    maxConcurrent: 512
     limit: 200
     maxAttempt: 3
     timeBudgetSec: 50
@@ -34,9 +36,9 @@ notification:
       ontimeSec: 60
       backfillSec: 600
     lease:
-      ontimeSec: 60
+      ontimeSec: 45
       backfillSec: 30
   writer:
     flush:
       batch: 500
-      intervalMs: 200
+      intervalMs: 1000

--- a/back/src/main/resources/properties/notification-worker.yml
+++ b/back/src/main/resources/properties/notification-worker.yml
@@ -1,0 +1,42 @@
+spring:
+  config.activate.on-profile: local
+notification:
+  dispatch:
+    limit: 200
+    maxAttempt: 3
+    timeBudgetSec: 50
+    leadMs: 600
+    guardMs: 500
+    backfillMinutes: 10
+    ttl:
+      ontimeSec: 60
+      backfillSec: 600
+    lease:
+      ontimeSec: 60
+      backfillSec: 30
+  writer:
+    flush:
+      batch: 500
+      intervalMs: 200
+
+---
+spring:
+  config.activate.on-profile: test
+notification:
+  dispatch:
+    limit: 200
+    maxAttempt: 3
+    timeBudgetSec: 50
+    leadMs: 600
+    guardMs: 500
+    backfillMinutes: 10
+    ttl:
+      ontimeSec: 60
+      backfillSec: 600
+    lease:
+      ontimeSec: 60
+      backfillSec: 30
+  writer:
+    flush:
+      batch: 500
+      intervalMs: 200

--- a/back/src/main/resources/properties/resilience.yml
+++ b/back/src/main/resources/properties/resilience.yml
@@ -19,13 +19,6 @@ resilience4j:
           - java.sql.SQLRecoverableException
         ignoreExceptions:
           - java.lang.IllegalArgumentException # 재시도해도 소용없는 것들
-  retry:
-    instances:
-      dbWriter:
-        maxAttempts: 1                   # 동기 재시도 사실상 "없음"(=0회 추가)
-        waitDuration: 0
-        retryExceptions:
-          - org.springframework.dao.TransientDataAccessException
 
 ---
 spring:
@@ -49,10 +42,3 @@ resilience4j:
           - java.sql.SQLRecoverableException
         ignoreExceptions:
           - java.lang.IllegalArgumentException # 재시도해도 소용없는 것들
-  retry:
-    instances:
-      dbWriter:
-        maxAttempts: 1
-        waitDuration: 0
-        retryExceptions:
-          - org.springframework.dao.TransientDataAccessException

--- a/back/src/main/resources/properties/resilience.yml
+++ b/back/src/main/resources/properties/resilience.yml
@@ -1,0 +1,58 @@
+spring:
+  config.activate.on-profile: local
+resilience4j:
+  circuitbreaker:
+    instances:
+      dbWriter:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 20            # 최근 20회 기준
+        minimumNumberOfCalls: 10
+        failureRateThreshold: 50         # 실패율 50% 이상이면 OPEN
+        waitDurationInOpenState: 5s      # OPEN 유지 시간
+        permittedNumberOfCallsInHalfOpenState: 5
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        recordExceptions:
+          - org.springframework.dao.DeadlockLoserDataAccessException
+          - org.springframework.dao.CannotAcquireLockException
+          - org.springframework.dao.TransientDataAccessException
+          - java.sql.SQLTransientException
+          - java.sql.SQLRecoverableException
+        ignoreExceptions:
+          - java.lang.IllegalArgumentException # 재시도해도 소용없는 것들
+  retry:
+    instances:
+      dbWriter:
+        maxAttempts: 1                   # 동기 재시도 사실상 "없음"(=0회 추가)
+        waitDuration: 0
+        retryExceptions:
+          - org.springframework.dao.TransientDataAccessException
+
+---
+spring:
+  config.activate.on-profile: test
+resilience4j:
+  circuitbreaker:
+    instances:
+      dbWriter:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 20            # 최근 20회 기준
+        minimumNumberOfCalls: 10
+        failureRateThreshold: 50         # 실패율 50% 이상이면 OPEN
+        waitDurationInOpenState: 5s      # OPEN 유지 시간
+        permittedNumberOfCallsInHalfOpenState: 5
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        recordExceptions:
+          - org.springframework.dao.DeadlockLoserDataAccessException
+          - org.springframework.dao.CannotAcquireLockException
+          - org.springframework.dao.TransientDataAccessException
+          - java.sql.SQLTransientException
+          - java.sql.SQLRecoverableException
+        ignoreExceptions:
+          - java.lang.IllegalArgumentException # 재시도해도 소용없는 것들
+  retry:
+    instances:
+      dbWriter:
+        maxAttempts: 1
+        waitDuration: 0
+        retryExceptions:
+          - org.springframework.dao.TransientDataAccessException

--- a/back/src/main/resources/properties/resilience.yml
+++ b/back/src/main/resources/properties/resilience.yml
@@ -8,7 +8,7 @@ resilience4j:
         slidingWindowSize: 20            # 최근 20회 기준
         minimumNumberOfCalls: 10
         failureRateThreshold: 50         # 실패율 50% 이상이면 OPEN
-        waitDurationInOpenState: 5s      # OPEN 유지 시간
+        waitDurationInOpenState: 10s      # OPEN 유지 시간
         permittedNumberOfCallsInHalfOpenState: 5
         automaticTransitionFromOpenToHalfOpenEnabled: true
         recordExceptions:
@@ -18,7 +18,24 @@ resilience4j:
           - java.sql.SQLTransientException
           - java.sql.SQLRecoverableException
         ignoreExceptions:
-          - java.lang.IllegalArgumentException # 재시도해도 소용없는 것들
+          - java.lang.IllegalArgumentException
+      fcm:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 50
+        minimumNumberOfCalls: 20
+        failureRateThreshold: 50
+        slowCallRateThreshold: 50
+        slowCallDurationThreshold: 5s # 10s
+        waitDurationInOpenState: 5s
+        permittedNumberOfCallsInHalfOpenState: 5
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        writableStackTraceEnabled: true # false
+        recordExceptions:
+          - java.util.concurrent.TimeoutException
+          - reactor.netty.http.client.PrematureCloseException
+          - com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventFcmRetryableException
+        ignoreExceptions:
+          - com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventFcmException
 
 ---
 spring:
@@ -41,4 +58,21 @@ resilience4j:
           - java.sql.SQLTransientException
           - java.sql.SQLRecoverableException
         ignoreExceptions:
-          - java.lang.IllegalArgumentException # 재시도해도 소용없는 것들
+          - java.lang.IllegalArgumentException
+      fcm:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 50
+        minimumNumberOfCalls: 20
+        failureRateThreshold: 50
+        slowCallRateThreshold: 50
+        slowCallDurationThreshold: 10s
+        waitDurationInOpenState: 5s
+        permittedNumberOfCallsInHalfOpenState: 5
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        writableStackTraceEnabled: false
+        recordExceptions:
+          - java.util.concurrent.TimeoutException
+          - reactor.netty.http.client.PrematureCloseException
+          - com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventFcmRetryableException
+        ignoreExceptions:
+          - com.rouby.notification.notificationEvent.infrastructure.exception.NotificationEventFcmException

--- a/back/src/test/http/notification-event.http
+++ b/back/src/test/http/notification-event.http
@@ -5,8 +5,8 @@ Content-Type: application/json
   "userId": 0,
   "tokenProviderType": "FCM",
   "deviceToken": "",
-  "title": "샘플 알림 제목",
-  "body": "샘플 알림 본문 내용입니다.",
+  "title": "Rouby - 브리핑 알림",
+  "body": "{}님, {}의 브리핑이 도착했습니다.",
   "url": "http://localhost:5173",
   "notificationType": "BRIEFING"
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #229

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
 
- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 알림 이벤트 도메인 컬럼 추가
  - [x] 그에 따른 브리핑 배치 작업 보완 및 디렉토리 구조 변경
  - [x] 쿼츠를 활용한 스케쥴링 수행
  - [x] 추가 스케쥴러를 활용한 발송 타이밍 보완
  - [x] 논블로킹 클라이언트를 활용한 알림 배치 전송 처리
  - [x] 알림용 토큰 갱신 처리 및 동시성 문제 방지
  - [x] 알림 전송 성공/실패 마킹 배치 처리 및 재시도/서킷브레이커 적용

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- 사용이 없는 코드도 포함이 되어 있습니다. 추후 리팩토링 수행할 예정입니다. 잠시 양해 부탁드릴게요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 알림 디스패처 도입: 정시/백필 처리, 비동기 전송, 결과 집계/플러시.
  - FCM HTTP v1 전송 지원 및 액세스 토큰 캐싱.
  - 알림 유형 추가: FEEDBACK, RECOMMENDATION, SCHEDULE_SYNC, ROUTINE_SYNC.
- 개선
  - 브리핑 알림에 예정 시각 포함 및 사용자별 스케줄링 강화.
  - 브리핑/알림 Quartz 잡 분리 및 트리거 추가.
- 성능/안정성
  - WebClient 커넥션 풀, HTTP/2, 회로 차단·재시도 적용.
- 설정
  - notification-worker.yml, resilience.yml 추가.
- 의존성
  - Firebase Admin SDK 업그레이드, WebFlux/Resilience4j 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->