### PR TITLE
[#238][notification] 알림 수신 idempotency 하도록 보완

### DIFF
--- a/front/public/firebase-messaging-sw.js
+++ b/front/public/firebase-messaging-sw.js
@@ -21,20 +21,137 @@ const firebaseConfig = {
 const app = firebase.initializeApp(firebaseConfig)
 const messaging = firebase.messaging()
 
-messaging.onBackgroundMessage((payload) => {
-  if (payload && payload.notification) {
-    return
+const DEDUPE_CH = 'noti-dedupe'
+const STORE = 'seen'
+const RETENTION_MS = 24 * 60 * 60_000 // 24 시간 보존
+const PRUNE_LIMIT = 1000
+
+// --- 알림 이벤트 중복 아이디 저장용 IDB 유틸 --
+function idbOpen() {
+  return new Promise((res, rej) => {
+    const r = indexedDB.open(DEDUPE_CH, 1)
+    r.onupgradeneeded = () => {
+      try {
+        r.result.createObjectStore(STORE) // key=id, value=ts(ms)
+      } catch (e) {
+        rej(e)
+        return
+      }
+    }
+    r.onsuccess = () => res(r.result)
+    r.onerror = () => rej(r.error)
+    r.onblocked = () => {
+      console.warn('IndexedDB update blocked. Closing other tabs might help.')
+    }
+  })
+}
+
+async function idbGet(id) {
+  const db = await idbOpen()
+
+  return new Promise((res, rej) => {
+    const tx = db.transaction(STORE, 'readonly')
+    const rq = tx.objectStore(STORE).get(id)
+    rq.onsuccess = () => res(rq.result ?? null)
+    rq.onerror = () => rej(rq.error)
+  })
+}
+
+async function idbPut(id, ts) {
+  const db = await idbOpen()
+
+  return new Promise((res, rej) => {
+    const tx = db.transaction(STORE, 'readwrite')
+    tx.objectStore(STORE).put(ts, id)
+    tx.oncomplete = () => res()
+    tx.onerror = () => rej(tx.error)
+  })
+}
+
+async function idbPrune(cutoff, limit = PRUNE_LIMIT) {
+  const db = await idbOpen()
+
+  return new Promise((res, rej) => {
+    const tx = db.transaction(STORE, 'readwrite')
+    const store = tx.objectStore(STORE)
+    const cur = store.openCursor()
+
+    let n = 0
+    cur.onsuccess = () => {
+      const c = cur.result
+      if (!c || n >= limit) return
+      const ts = c.value
+      if (typeof ts === 'number' && ts < cutoff) {
+        c.delete()
+        n++
+      }
+      c.continue()
+    }
+    tx.oncomplete = () => res(n)
+    tx.onerror = () => rej(tx.error)
+  })
+}
+
+// --- 알림 이벤트 전파 ---
+const bc = 'BroadcastChannel' in self ? new BroadcastChannel(DEDUPE_CH) : null
+const broadcastToPages = async (msg) => {
+  if (bc) {
+    bc.postMessage(msg)
+  } else {
+    const cs = await self.clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true,
+    })
+    cs.forEach((c) => c.postMessage(msg))
   }
+}
+
+const resolvePropagatedEvent = async (e) => {
+  const { id, ts } = e.data || {}
+
+  if (id && typeof ts === 'number') {
+    const storedTs = await idbGet(id)
+    if (storedTs && typeof storedTs === 'number') return
+
+    idbPut(id, ts).catch(() => {})
+  }
+}
+bc && bc.addEventListener('message', resolvePropagatedEvent)
+self.addEventListener('message', resolvePropagatedEvent)
+
+// --- 알림 이벤트 중복 체크 + 기록 ---
+async function markAndCheckSeen(id) {
+  if (!id) return false
+
+  const ts = await idbGet(id)
+  if (ts && typeof ts === 'number') return true
+
+  const now = Date.now()
+  idbPut(id, now).catch(() => {})
+  if (Math.random() < 0.1) idbPrune(now - RETENTION_MS).catch(() => {})
+
+  broadcastToPages({ id, ts: now })
+  return false
+}
+
+// --- 알림 이벤트 수신 ---
+messaging.onBackgroundMessage(async (payload) => {
+  if (payload && payload.notification) return
 
   const data = payload?.data || {}
+  const id = data.eventId
+  if (id && (await markAndCheckSeen(id))) return
+
   const title = data.title || '알림'
   const options = {
     body: data.body || '',
     icon: data.icon || '/assets/header_logo.svg',
     data: { url: data.url || '/' },
+    tag: id ? `evt:${id}` : (payload.data?.tag ?? 'rouby'),
   }
 
   self.registration.showNotification(title, options)
+  if (id) await broadcastToPages({ id, ts: Date.now() })
 })
 
 self.addEventListener('notificationclick', (event) => {

--- a/front/src/features/schedule/useScheduleForm.js
+++ b/front/src/features/schedule/useScheduleForm.js
@@ -51,6 +51,7 @@ export const useScheduleForm = (initValues = {}) => {
       repeat: null,
     })
   }
+
   const form = createInitialForm()
   const isSubmitting = ref(false)
   const errors = reactive({})

--- a/front/src/shared/firebase/config.js
+++ b/front/src/shared/firebase/config.js
@@ -57,7 +57,52 @@ if (!globalThis.__firebaseApp__) {
 }
 export const app = globalThis.__firebaseApp__
 export const regSw = await ensureSw()
+
 const toast = useToast()
+
+const seen = new Map()
+const DEDUPE_CH = 'noti-dedupe'
+const MAX_SEEN = 1000
+const TRIM_COUNT = 500
+
+const bc = 'BroadcastChannel' in window ? new BroadcastChannel(DEDUPE_CH) : null
+bc.onmessage = (e) => {
+  const { id, ts } = e.data || {}
+  if (id) seen.set(id, ts)
+}
+
+const markAndCheckSeen = (id) => {
+  if (seen.has(id)) return true
+
+  const now = Date.now()
+  seen.set(id, now)
+
+  if (seen.size > MAX_SEEN) {
+    let i = 0
+    for (const key of seen.keys()) {
+      seen.delete(key)
+      if (++i >= TRIM_COUNT) break
+    }
+  }
+
+  if (bc) bc.postMessage({ id, ts: now })
+  else navigator.serviceWorker?.controller?.postMessage({ id, ts: now })
+  return false
+}
+
+// --- 탭 간 수신(BC 우선, SW 폴백) ---
+const resolvePropagatedEvent = (e) => {
+  const { id, ts } = e.data || {}
+  if (id && typeof ts === 'number') {
+    const prev = seen.get(id) ?? 0
+    if (ts > prev) seen.set(id, ts)
+  }
+}
+bc?.addEventListener('message', (e) => resolvePropagatedEvent)
+navigator.serviceWorker?.addEventListener(
+  'message',
+  (e) => resolvePropagatedEvent,
+)
 
 let isForegroundListenerRegistered = false
 export const listenForeground = () => {
@@ -67,6 +112,9 @@ export const listenForeground = () => {
 
   const messaging = getMessaging(app)
   onMessage(messaging, async (payload) => {
+    const id = payload.data?.eventId
+    if (id && markAndCheckSeen(id)) return
+
     const title = payload.notification?.title ?? payload.data?.title ?? '알림'
     const body = payload.notification?.body ?? payload.data?.body ?? ''
     const url = payload.fcmOptions?.link ?? payload.data?.url ?? '/'
@@ -83,8 +131,8 @@ export const listenForeground = () => {
             DEFAULT_ICON_PATH,
           badge: DEFAULT_BADGE_PATH,
           data: { url },
-          tag: payload.data?.tag ?? 'rouby',
-          renotify: true,
+          tag: id ? 'evt:' + id : (payload.data?.tag ?? 'rouby'),
+          renotify: false,
           requireInteraction: false,
         })
         return

--- a/front/src/shared/firebase/config.js
+++ b/front/src/shared/firebase/config.js
@@ -66,7 +66,7 @@ const MAX_SEEN = 1000
 const TRIM_COUNT = 500
 
 const bc = 'BroadcastChannel' in window ? new BroadcastChannel(DEDUPE_CH) : null
-bc.onmessage = (e) => {
+bc?.onmessage = (e) => {
   const { id, ts } = e.data || {}
   if (id) seen.set(id, ts)
 }
@@ -98,11 +98,8 @@ const resolvePropagatedEvent = (e) => {
     if (ts > prev) seen.set(id, ts)
   }
 }
-bc?.addEventListener('message', (e) => resolvePropagatedEvent)
-navigator.serviceWorker?.addEventListener(
-  'message',
-  (e) => resolvePropagatedEvent,
-)
+bc?.addEventListener('message', resolvePropagatedEvent)
+navigator.serviceWorker?.addEventListener('message', resolvePropagatedEvent)
 
 let isForegroundListenerRegistered = false
 export const listenForeground = () => {


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #238

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 알림 수신 idempotency 하도록 보완
 
## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 푸시 알림 중복 방지 도입: 이벤트 ID 기반으로 탭·서비스 워커 간 동기화하여 탭당 단일 알림을 보장합니다.
  - 백그라운드·포어그라운드 모두에 적용되며, 알림 태그와 재알림(renotify) 동작을 조정해 중복 표시를 최소화합니다.
  - 브로드캐스트로 빠른 전파 및 로컬 보존/정리 정책으로 안정성을 개선했습니다.
  - 알림 클릭 동작은 기존과 동일합니다.
- Style
  - 일정 폼 초기화 코드의 공백 정리(기능 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->