### PR TITLE
[#242][be][schedule]feat: 일정 삭제(해당 일정 삭제/이후 일정 삭제)

### DIFF
--- a/back/src/docs/asciidoc/schedule.adoc
+++ b/back/src/docs/asciidoc/schedule.adoc
@@ -79,7 +79,7 @@ include::{snippets}/update-schedule-invalid-alarm-offset-400/http-response.adoc[
 
 ---
 
-[[Delete-Schedules]]
+[[Delete-Schedules-]]
 == 해당 일정 삭제 API
 
 === 성공: 해당 일정 삭제 요청
@@ -105,7 +105,7 @@ include::{snippets}/delete-schedule-invalid-400/http-response.adoc[]
 
 ---
 
-[[Delete-Schedules]]
+[[Delete-Schedules-From]]
 == 이후 일정 삭제 API
 
 === 성공: 이후 일정 모두 삭제 요청

--- a/back/src/docs/asciidoc/schedule.adoc
+++ b/back/src/docs/asciidoc/schedule.adoc
@@ -78,3 +78,45 @@ include::{snippets}/update-schedule-invalid-alarm-offset-400/http-request.adoc[]
 include::{snippets}/update-schedule-invalid-alarm-offset-400/http-response.adoc[]
 
 ---
+
+[[Delete-Schedules]]
+== 해당 일정 삭제 API
+
+=== 성공: 해당 일정 삭제 요청
+
+==== HTTP 요청
+include::{snippets}/delete-schedule-200/http-request.adoc[]
+
+==== 요청 필드
+include::{snippets}/delete-schedule-200/request-fields.adoc[]
+
+==== HTTP 응답 (200 OK)
+include::{snippets}/delete-schedule-200/http-response.adoc[]
+
+=== 실패: 유효성 검증 오류
+
+==== 알람 설정 시간 오류
+
+===== HTTP 요청
+include::{snippets}/delete-schedule-invalid-400/http-request.adoc[]
+
+===== HTTP 응답 (400 Bad Request)
+include::{snippets}/delete-schedule-invalid-400/http-response.adoc[]
+
+---
+
+[[Delete-Schedules]]
+== 이후 일정 삭제 API
+
+=== 성공: 이후 일정 모두 삭제 요청
+
+==== HTTP 요청
+include::{snippets}/delete-schedule-from-200/http-request.adoc[]
+
+==== 요청 필드
+include::{snippets}/delete-schedule-from-200/request-fields.adoc[]
+
+==== HTTP 응답 (200 OK)
+include::{snippets}/delete-schedule-from-200/http-response.adoc[]
+
+---

--- a/back/src/main/java/com/rouby/schedule/application/dto/DeleteScheduleCommand.java
+++ b/back/src/main/java/com/rouby/schedule/application/dto/DeleteScheduleCommand.java
@@ -1,0 +1,34 @@
+package com.rouby.schedule.application.dto;
+
+import com.rouby.schedule.domain.entity.Schedule;
+import com.rouby.schedule.domain.enums.OverrideType;
+import com.rouby.schedule.domain.vo.OverrideInfo;
+import com.rouby.schedule.domain.vo.Period;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record DeleteScheduleCommand(
+    Long scheduleId,
+    LocalDate instanceDate,
+    LocalDateTime startAt,
+    LocalDateTime endAt
+) {
+
+  public Schedule toEntityWithUserId(Long userId, Schedule schedule, LocalDate instanceDate,
+      LocalDateTime startAt, LocalDateTime endAt) {
+    return Schedule.createByOverride(
+        userId,
+        schedule.getTitle(),
+        schedule.getMemo(),
+        Period.builder()
+            .startAt(startAt)
+            .endAt(endAt)
+            .build(),
+        schedule.getAlarmOffsetType().getMinutes(),
+        schedule,
+        OverrideInfo.builder()
+            .overrideDate(instanceDate)
+            .overrideType(OverrideType.CANCELLED)
+            .build());
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/application/dto/DeleteScheduleCommand.java
+++ b/back/src/main/java/com/rouby/schedule/application/dto/DeleteScheduleCommand.java
@@ -14,8 +14,7 @@ public record DeleteScheduleCommand(
     LocalDateTime endAt
 ) {
 
-  public Schedule toEntityWithUserId(Long userId, Schedule schedule, LocalDate instanceDate,
-      LocalDateTime startAt, LocalDateTime endAt) {
+  public Schedule toEntityWithUserId(Long userId, Schedule schedule) {
     return Schedule.createByOverride(
         userId,
         schedule.getTitle(),

--- a/back/src/main/java/com/rouby/schedule/application/dto/DeleteScheduleFromCommand.java
+++ b/back/src/main/java/com/rouby/schedule/application/dto/DeleteScheduleFromCommand.java
@@ -1,0 +1,10 @@
+package com.rouby.schedule.application.dto;
+
+import java.time.LocalDateTime;
+
+public record DeleteScheduleFromCommand(
+    Long scheduleId,
+    LocalDateTime fromAt
+) {
+
+}

--- a/back/src/main/java/com/rouby/schedule/application/dto/command/UpdateScheduleCommand.java
+++ b/back/src/main/java/com/rouby/schedule/application/dto/command/UpdateScheduleCommand.java
@@ -21,7 +21,7 @@ public record UpdateScheduleCommand(
 ) {
 
   public Schedule toEntityWithUserId(Long userId, Schedule parentSchedule) {
-    return Schedule.createByModify(
+    return Schedule.createByOverride(
         userId,
         title,
         memo,

--- a/back/src/main/java/com/rouby/schedule/application/facade/ScheduleFacade.java
+++ b/back/src/main/java/com/rouby/schedule/application/facade/ScheduleFacade.java
@@ -1,5 +1,7 @@
 package com.rouby.schedule.application.facade;
 
+import com.rouby.schedule.application.dto.DeleteScheduleCommand;
+import com.rouby.schedule.application.dto.DeleteScheduleFromCommand;
 import com.rouby.schedule.application.dto.command.CreateScheduleCommand;
 import com.rouby.schedule.application.dto.command.UpdateScheduleCommand;
 import com.rouby.schedule.application.dto.info.SchedulesInfo;
@@ -26,5 +28,14 @@ public class ScheduleFacade {
 
   public Long updateSchedule(Long userId, UpdateScheduleCommand command) {
     return scheduleWriteService.updateSchedule(userId, command);
+  }
+
+  public void deleteSchedule(Long userId, DeleteScheduleCommand command) {
+    scheduleWriteService.deleteSchedule(userId, command);
+  }
+
+  public void deleteSchedulesStartingFrom(Long userId, DeleteScheduleFromCommand command) {
+    scheduleWriteService.deleteFromSchedule(userId, command);
+
   }
 }

--- a/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
+++ b/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
@@ -1,6 +1,8 @@
 package com.rouby.schedule.application.service;
 
 
+import com.rouby.schedule.application.dto.DeleteScheduleCommand;
+import com.rouby.schedule.application.dto.DeleteScheduleFromCommand;
 import com.rouby.schedule.application.dto.command.CreateScheduleCommand;
 import com.rouby.schedule.application.dto.command.UpdateScheduleCommand;
 import com.rouby.schedule.application.exception.ScheduleErrorCode;
@@ -62,6 +64,44 @@ public class ScheduleWriteService {
       return schedule.getId();
     } catch (IllegalArgumentException e) {
       throw ScheduleException.of(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST, e.getMessage());
+    }
+  }
+
+  @Transactional
+  public void deleteSchedule(Long userId, DeleteScheduleCommand command) {
+    Schedule schedule = scheduleRepository.findById(command.scheduleId())
+        .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+
+    if (!Objects.equals(schedule.getUserId(), userId)) {
+      throw ScheduleException.from(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST);
+    }
+
+    Schedule parentSchedule = schedule.getParentSchedule();
+
+    if (parentSchedule != null) {
+      schedule.cancel();
+    } else {
+      Schedule newSchedule = command.toEntityWithUserId(
+          userId, schedule, command.instanceDate(), command.startAt(), command.endAt());
+      scheduleRepository.save(newSchedule);
+    }
+  }
+
+  @Transactional
+  public void deleteFromSchedule(Long userId, DeleteScheduleFromCommand command) {
+    Schedule schedule = scheduleRepository.findById(command.scheduleId())
+        .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
+
+    if (!Objects.equals(schedule.getUserId(), userId)) {
+      throw ScheduleException.from(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST);
+    }
+
+    Schedule parentSchedule = schedule.getParentSchedule();
+
+    if (parentSchedule != null) {
+      parentSchedule.cancelFrom(command.fromAt());
+    } else {
+      schedule.cancelFrom(command.fromAt());
     }
   }
 }

--- a/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
+++ b/back/src/main/java/com/rouby/schedule/application/service/ScheduleWriteService.java
@@ -69,39 +69,32 @@ public class ScheduleWriteService {
 
   @Transactional
   public void deleteSchedule(Long userId, DeleteScheduleCommand command) {
-    Schedule schedule = scheduleRepository.findById(command.scheduleId())
+    Schedule schedule = scheduleRepository.findByIdAndUserId(command.scheduleId(), userId)
         .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
-
-    if (!Objects.equals(schedule.getUserId(), userId)) {
-      throw ScheduleException.from(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST);
-    }
 
     Schedule parentSchedule = schedule.getParentSchedule();
 
     if (parentSchedule != null) {
       schedule.cancel();
     } else {
-      Schedule newSchedule = command.toEntityWithUserId(
-          userId, schedule, command.instanceDate(), command.startAt(), command.endAt());
+      Schedule newSchedule = command.toEntityWithUserId(userId, schedule);
       scheduleRepository.save(newSchedule);
     }
   }
 
   @Transactional
   public void deleteFromSchedule(Long userId, DeleteScheduleFromCommand command) {
-    Schedule schedule = scheduleRepository.findById(command.scheduleId())
+    Schedule schedule = scheduleRepository.findByIdAndUserId(command.scheduleId(), userId)
         .orElseThrow(() -> ScheduleException.from(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
-
-    if (!Objects.equals(schedule.getUserId(), userId)) {
-      throw ScheduleException.from(ScheduleErrorCode.SCHEDULE_INVALID_REQUEST);
-    }
 
     Schedule parentSchedule = schedule.getParentSchedule();
 
     if (parentSchedule != null) {
       parentSchedule.cancelFrom(command.fromAt());
+      scheduleRepository.bulkCancel(parentSchedule.getId(), command.fromAt());
     } else {
       schedule.cancelFrom(command.fromAt());
+      scheduleRepository.bulkCancel(schedule.getId(), command.fromAt());
     }
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
@@ -161,6 +161,8 @@ public class Schedule extends BaseEntity {
   }
 
   public void cancelFrom(LocalDateTime fromAt) {
-    this.recurrenceRule.cutUntil(fromAt.minusSeconds(1));
+    if (this.recurrenceRule != null) {
+      this.recurrenceRule.cutUntil(fromAt.minusSeconds(1));
+    }
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/entity/Schedule.java
@@ -21,6 +21,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -74,7 +75,7 @@ public class Schedule extends BaseEntity {
   @Embedded
   private OverrideInfo overrideInfo;
 
-  public static Schedule createByModify(Long userId, String title, String memo, Period period,
+  public static Schedule createByOverride(Long userId, String title, String memo, Period period,
       Integer alarmOffsetMinutes, Schedule parentSchedule, OverrideInfo overrideInfo) {
     return Schedule.builder()
         .userId(userId)
@@ -153,5 +154,13 @@ public class Schedule extends BaseEntity {
 
   private boolean isRoutineActivateDateOneMoreDayBefore() {
     return period.getStartAt().toLocalDate().minusDays(routineOffsetDays).isBefore(LocalDate.now().minusDays(1));
+  }
+
+  public void cancel() {
+    this.overrideInfo.cancel();
+  }
+
+  public void cancelFrom(LocalDateTime fromAt) {
+    this.recurrenceRule.cutUntil(fromAt.minusSeconds(1));
   }
 }

--- a/back/src/main/java/com/rouby/schedule/domain/repository/ScheduleRepository.java
+++ b/back/src/main/java/com/rouby/schedule/domain/repository/ScheduleRepository.java
@@ -3,6 +3,7 @@ package com.rouby.schedule.domain.repository;
 import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.repository.criteria.GetScheduleCriteria;
 import com.rouby.schedule.domain.repository.info.ScheduleWithOverrides;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,6 @@ public interface ScheduleRepository {
   Optional<Schedule> findById(Long id);
 
   Optional<Schedule> findByIdAndUserId(Long id, Long userId);
+
+  void bulkCancel(Long id, LocalDateTime untilAt);
 }

--- a/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/OverrideInfo.java
@@ -31,6 +31,10 @@ public class OverrideInfo {
     this.overrideDate = overrideDate;
   }
 
+  public void cancel() {
+    this.overrideType = CANCELLED;
+  }
+
   public boolean isCancelled() {
     return overrideType == CANCELLED;
   }

--- a/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
+++ b/back/src/main/java/com/rouby/schedule/domain/vo/RecurrenceRule.java
@@ -107,6 +107,13 @@ public class RecurrenceRule implements Serializable {
     this.freq.validateInterval(this.interval);
   }
 
+  public void cutUntil(LocalDateTime until) {
+    if (this.until != null && this.until.isBefore(until)) {
+      return;
+    }
+    this.until = until;
+  }
+
   @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
   enum RuleType {
     FREQ(str -> Freq.valueOf(str),

--- a/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepository.java
+++ b/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepository.java
@@ -2,7 +2,6 @@ package com.rouby.schedule.infrastructure.persistence.jpa;
 
 import com.rouby.schedule.domain.entity.Schedule;
 import com.rouby.schedule.domain.repository.ScheduleRepository;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleJpaRepository extends

--- a/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepositoryCustom.java
+++ b/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepositoryCustom.java
@@ -2,9 +2,12 @@ package com.rouby.schedule.infrastructure.persistence.jpa;
 
 import com.rouby.schedule.domain.repository.criteria.GetScheduleCriteria;
 import com.rouby.schedule.domain.repository.info.ScheduleWithOverrides;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleJpaRepositoryCustom {
 
   List<ScheduleWithOverrides> findSchedulesByCriteria(GetScheduleCriteria condition);
+
+  void bulkCancel(Long id, LocalDateTime untilAt);
 }

--- a/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepositoryCustomImpl.java
+++ b/back/src/main/java/com/rouby/schedule/infrastructure/persistence/jpa/ScheduleJpaRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.rouby.schedule.domain.entity.QSchedule;
+import com.rouby.schedule.domain.enums.OverrideType;
 import com.rouby.schedule.domain.repository.criteria.GetScheduleCriteria;
 import com.rouby.schedule.domain.repository.info.ScheduleWithOverrides;
 import com.rouby.schedule.domain.repository.info.ScheduleWithOverrides.ScheduleOverride;
@@ -23,6 +24,18 @@ public class ScheduleJpaRepositoryCustomImpl implements ScheduleJpaRepositoryCus
 
   private final JPAQueryFactory jpaQueryFactory;
   private final QSchedule child = new QSchedule("child");
+
+  @Override
+  public void bulkCancel(Long parentScheduleId, LocalDateTime fromAt) {
+    jpaQueryFactory.update(schedule)
+        .set(schedule.overrideInfo.overrideType, OverrideType.CANCELLED)
+        .where(
+            schedule.parentSchedule.id.eq(parentScheduleId),
+            schedule.period.startAt.goe(fromAt),
+            schedule.deletedAt.isNull()
+        )
+        .execute();
+  }
 
   @Override
   public List<ScheduleWithOverrides> findSchedulesByCriteria(GetScheduleCriteria criteria) {

--- a/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
@@ -71,7 +71,7 @@ public class ScheduleController {
       @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated DeleteScheduleRequest req) {
 
     scheduleFacade.deleteSchedule(securityUser.getId(), req.toCommand());
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
   }
 
   @PreAuthorize("hasAnyRole('USER')")
@@ -80,6 +80,6 @@ public class ScheduleController {
       @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated DeleteScheduleFromRequest req) {
 
     scheduleFacade.deleteSchedulesStartingFrom(securityUser.getId(), req.toCommand());
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok().build();
   }
 }

--- a/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -64,9 +65,8 @@ public class ScheduleController {
     return ResponseEntity.ok().body(scheduleId);
   }
 
-  // 하나만 삭제
   @PreAuthorize("hasAnyRole('USER')")
-  @DeleteMapping
+  @PatchMapping
   public ResponseEntity<Void> deleteSchedule(
       @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated DeleteScheduleRequest req) {
 
@@ -74,9 +74,8 @@ public class ScheduleController {
     return ResponseEntity.noContent().build();
   }
 
-  // 이후 일정 삭제
   @PreAuthorize("hasAnyRole('USER')")
-  @DeleteMapping("/from")
+  @PatchMapping("/from")
   public ResponseEntity<Void> deleteSchedulesStartingFrom(
       @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated DeleteScheduleFromRequest req) {
 

--- a/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
@@ -71,7 +71,7 @@ public class ScheduleController {
       @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated DeleteScheduleRequest req) {
 
     scheduleFacade.deleteSchedule(securityUser.getId(), req.toCommand());
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 
   // 이후 일정 삭제
@@ -81,6 +81,6 @@ public class ScheduleController {
       @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated DeleteScheduleFromRequest req) {
 
     scheduleFacade.deleteSchedulesStartingFrom(securityUser.getId(), req.toCommand());
-    return ResponseEntity.ok().build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/ScheduleController.java
@@ -1,6 +1,8 @@
 package com.rouby.schedule.presentation;
 
 import com.rouby.schedule.application.facade.ScheduleFacade;
+import com.rouby.schedule.presentation.dto.DeleteScheduleFromRequest;
+import com.rouby.schedule.presentation.dto.DeleteScheduleRequest;
 import com.rouby.schedule.presentation.dto.request.CreateScheduleRequest;
 import com.rouby.schedule.presentation.dto.request.GetScheduleRequest;
 import com.rouby.schedule.presentation.dto.request.UpdateScheduleRequest;
@@ -12,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -59,5 +62,25 @@ public class ScheduleController {
 
     Long scheduleId = scheduleFacade.updateSchedule(securityUser.getId(), req.toCommand());
     return ResponseEntity.ok().body(scheduleId);
+  }
+
+  // 하나만 삭제
+  @PreAuthorize("hasAnyRole('USER')")
+  @DeleteMapping
+  public ResponseEntity<Void> deleteSchedule(
+      @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated DeleteScheduleRequest req) {
+
+    scheduleFacade.deleteSchedule(securityUser.getId(), req.toCommand());
+    return ResponseEntity.ok().build();
+  }
+
+  // 이후 일정 삭제
+  @PreAuthorize("hasAnyRole('USER')")
+  @DeleteMapping("/from")
+  public ResponseEntity<Void> deleteSchedulesStartingFrom(
+      @AuthenticationPrincipal SecurityUser securityUser, @RequestBody @Validated DeleteScheduleFromRequest req) {
+
+    scheduleFacade.deleteSchedulesStartingFrom(securityUser.getId(), req.toCommand());
+    return ResponseEntity.ok().build();
   }
 }

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/DeleteScheduleFromRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/DeleteScheduleFromRequest.java
@@ -1,10 +1,15 @@
 package com.rouby.schedule.presentation.dto;
 
 import com.rouby.schedule.application.dto.DeleteScheduleFromCommand;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public record DeleteScheduleFromRequest(
+
+    @NotNull(message = "스케줄 ID는 필수입니다.")
     Long scheduleId,
+
+    @NotNull(message = "삭제 기준 시점은 필수입니다.")
     LocalDateTime fromAt
 ) {
 

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/DeleteScheduleFromRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/DeleteScheduleFromRequest.java
@@ -1,0 +1,14 @@
+package com.rouby.schedule.presentation.dto;
+
+import com.rouby.schedule.application.dto.DeleteScheduleFromCommand;
+import java.time.LocalDateTime;
+
+public record DeleteScheduleFromRequest(
+    Long scheduleId,
+    LocalDateTime fromAt
+) {
+
+  public DeleteScheduleFromCommand toCommand() {
+    return new DeleteScheduleFromCommand(scheduleId, fromAt);
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/DeleteScheduleRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/DeleteScheduleRequest.java
@@ -1,0 +1,17 @@
+package com.rouby.schedule.presentation.dto;
+
+import com.rouby.schedule.application.dto.DeleteScheduleCommand;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record DeleteScheduleRequest(
+    Long scheduleId,
+    LocalDate instanceDate,
+    LocalDateTime startAt,
+    LocalDateTime endAt
+) {
+
+  public DeleteScheduleCommand toCommand() {
+    return new DeleteScheduleCommand(scheduleId, instanceDate, startAt, endAt);
+  }
+}

--- a/back/src/main/java/com/rouby/schedule/presentation/dto/DeleteScheduleRequest.java
+++ b/back/src/main/java/com/rouby/schedule/presentation/dto/DeleteScheduleRequest.java
@@ -1,13 +1,22 @@
 package com.rouby.schedule.presentation.dto;
 
 import com.rouby.schedule.application.dto.DeleteScheduleCommand;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record DeleteScheduleRequest(
+
+    @NotNull(message = "스케줄 ID는 필수입니다.")
     Long scheduleId,
+
+    @NotNull(message = "인스턴스 날짜는 필수입니다.")
     LocalDate instanceDate,
+
+    @NotNull(message = "시작일자는 필수입니다.")
     LocalDateTime startAt,
+
+    @NotNull(message = "종료일자는 필수입니다.")
     LocalDateTime endAt
 ) {
 

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-@Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
+//@Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
 @SpringBootTest
 public class ScheduleTestDataSaver {
 

--- a/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
+++ b/back/src/test/java/com/rouby/schedule/data/ScheduleTestDataSaver.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-//@Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
+@Disabled("필요한 경우 해당 어노테이션을 주석 처리하고 사용해주세요.")
 @SpringBootTest
 public class ScheduleTestDataSaver {
 

--- a/back/src/test/java/com/rouby/schedule/fixture/DeleteScheduleFromRequestFixture.java
+++ b/back/src/test/java/com/rouby/schedule/fixture/DeleteScheduleFromRequestFixture.java
@@ -1,0 +1,21 @@
+package com.rouby.schedule.fixture;
+
+import com.rouby.schedule.presentation.dto.DeleteScheduleFromRequest;
+import java.time.LocalDateTime;
+
+public class DeleteScheduleFromRequestFixture {
+
+  public static DeleteScheduleFromRequest getSuccessRequest() {
+    return new DeleteScheduleFromRequest(
+        1L,
+        LocalDateTime.of(2025, 9, 15, 10, 0)
+    );
+  }
+
+  public static DeleteScheduleFromRequest getPastDateRequest() {
+    return new DeleteScheduleFromRequest(
+        1L,
+        LocalDateTime.of(2020, 1, 1, 10, 0) // 과거 날짜 예시
+    );
+  }
+}

--- a/back/src/test/java/com/rouby/schedule/fixture/DeleteScheduleRequestFixture.java
+++ b/back/src/test/java/com/rouby/schedule/fixture/DeleteScheduleRequestFixture.java
@@ -1,0 +1,26 @@
+package com.rouby.schedule.fixture;
+
+import com.rouby.schedule.presentation.dto.DeleteScheduleRequest;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class DeleteScheduleRequestFixture {
+
+  public static DeleteScheduleRequest getSuccessRequest() {
+    return new DeleteScheduleRequest(
+        1L,
+        LocalDate.of(2025, 9, 15),
+        LocalDateTime.of(2025, 9, 15, 10, 0),
+        LocalDateTime.of(2025, 9, 15, 12, 0)
+    );
+  }
+
+  public static DeleteScheduleRequest getInvalidDateRequest() {
+    return new DeleteScheduleRequest(
+        1L,
+        LocalDate.of(2025, 9, 15),
+        LocalDateTime.of(2025, 9, 15, 12, 0),
+        LocalDateTime.of(2025, 9, 15, 10, 0)
+    );
+  }
+}

--- a/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
+++ b/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -280,7 +280,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
   }
 
   @WithMockCustomUser
-  @DisplayName("스케쥴 단일 삭제 API - 성공 204")
+  @DisplayName("스케쥴 단일 삭제 API - 성공 200")
   @Test
   void deleteSchedule() throws Exception {
 
@@ -292,7 +292,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
 
     // when
     ResultActions resultActions = mockMvc.perform(
-        delete("/api/v1/schedules") // 실제 컨트롤러 매핑에 맞게 수정
+        patch("/api/v1/schedules") // 실제 컨트롤러 매핑에 맞게 수정
             .header("Authorization", "Bearer {ACCESS_TOKEN}")
             .content(content)
             .characterEncoding("UTF-8")
@@ -300,7 +300,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
     );
 
     // then
-    resultActions.andExpect(status().isNoContent())
+    resultActions.andExpect(status().isOk())
         .andDo(print())
         .andDo(document("delete-schedule-204",
             preprocessRequest(prettyPrint()),
@@ -315,7 +315,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
   }
 
   @WithMockCustomUser
-  @DisplayName("스케쥴 반복 이후 삭제 API - 성공 204")
+  @DisplayName("스케쥴 반복 이후 삭제 API - 성공 200")
   @Test
   void deleteScheduleFrom() throws Exception {
 
@@ -327,7 +327,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
 
     // when
     ResultActions resultActions = mockMvc.perform(
-        delete("/api/v1/schedules/from")
+        patch("/api/v1/schedules/from")
             .header("Authorization", "Bearer {ACCESS_TOKEN}")
             .content(content)
             .characterEncoding("UTF-8")
@@ -335,7 +335,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
     );
 
     // then
-    resultActions.andExpect(status().isNoContent())
+    resultActions.andExpect(status().isOk())
         .andDo(print())
         .andDo(document("delete-schedule-from-204",
             preprocessRequest(prettyPrint()),
@@ -361,7 +361,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
 
     // when
     ResultActions resultActions = mockMvc.perform(
-        delete("/api/v1/schedules")
+        patch("/api/v1/schedules")
             .header("Authorization", "Bearer {ACCESS_TOKEN}")
             .content(content)
             .characterEncoding("UTF-8")

--- a/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
+++ b/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
@@ -300,9 +300,9 @@ class ScheduleControllerTest extends ControllerTestSupport {
     );
 
     // then
-    resultActions.andExpect(status().isOk())
+    resultActions.andExpect(status().isNoContent())
         .andDo(print())
-        .andDo(document("delete-schedule-200",
+        .andDo(document("delete-schedule-204",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
             requestFields(
@@ -335,9 +335,9 @@ class ScheduleControllerTest extends ControllerTestSupport {
     );
 
     // then
-    resultActions.andExpect(status().isOk())
+    resultActions.andExpect(status().isNoContent())
         .andDo(print())
-        .andDo(document("delete-schedule-from-200",
+        .andDo(document("delete-schedule-from-204",
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
             requestFields(

--- a/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
+++ b/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
@@ -280,7 +280,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
   }
 
   @WithMockCustomUser
-  @DisplayName("스케쥴 단일 삭제 API - 성공 200")
+  @DisplayName("스케쥴 단일 삭제 API - 성공 204")
   @Test
   void deleteSchedule() throws Exception {
 
@@ -315,7 +315,7 @@ class ScheduleControllerTest extends ControllerTestSupport {
   }
 
   @WithMockCustomUser
-  @DisplayName("스케쥴 반복 이후 삭제 API - 성공 200")
+  @DisplayName("스케쥴 반복 이후 삭제 API - 성공 204")
   @Test
   void deleteScheduleFrom() throws Exception {
 

--- a/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
+++ b/back/src/test/java/com/rouby/schedule/presentation/ScheduleControllerTest.java
@@ -1,6 +1,7 @@
 package com.rouby.schedule.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -14,6 +15,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -22,6 +24,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.rouby.common.security.WithMockCustomUser;
 import com.rouby.common.support.ControllerTestSupport;
 import com.rouby.schedule.fixture.CreateScheduleRequestFixture;
+import com.rouby.schedule.fixture.DeleteScheduleFromRequestFixture;
+import com.rouby.schedule.fixture.DeleteScheduleRequestFixture;
 import com.rouby.schedule.fixture.GetScheduleRequestFixture;
 import com.rouby.schedule.fixture.SchedulesInfoFixture;
 import com.rouby.schedule.fixture.UpdateScheduleRequestFixture;
@@ -274,4 +278,104 @@ class ScheduleControllerTest extends ControllerTestSupport {
             getErrorResponseFieldSnippet()
         ));
   }
+
+  @WithMockCustomUser
+  @DisplayName("스케쥴 단일 삭제 API - 성공 200")
+  @Test
+  void deleteSchedule() throws Exception {
+
+    // given
+    var request = DeleteScheduleRequestFixture.getSuccessRequest();
+    var content = objectMapper.writeValueAsString(request);
+
+    doNothing().when(scheduleFacade).deleteSchedule(any(Long.class), any());
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        delete("/api/v1/schedules") // 실제 컨트롤러 매핑에 맞게 수정
+            .header("Authorization", "Bearer {ACCESS_TOKEN}")
+            .content(content)
+            .characterEncoding("UTF-8")
+            .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andDo(print())
+        .andDo(document("delete-schedule-200",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("scheduleId").description("삭제할 일정 아이디"),
+                fieldWithPath("instanceDate").description("삭제 기준 instanceDate"),
+                fieldWithPath("startAt").description("삭제 대상 시작 일시"),
+                fieldWithPath("endAt").description("삭제 대상 종료 일시")
+            )
+        ));
+  }
+
+  @WithMockCustomUser
+  @DisplayName("스케쥴 반복 이후 삭제 API - 성공 200")
+  @Test
+  void deleteScheduleFrom() throws Exception {
+
+    // given
+    var request = DeleteScheduleFromRequestFixture.getSuccessRequest();
+    var content = objectMapper.writeValueAsString(request);
+
+    doNothing().when(scheduleFacade).deleteSchedulesStartingFrom(any(Long.class), any());
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        delete("/api/v1/schedules/from")
+            .header("Authorization", "Bearer {ACCESS_TOKEN}")
+            .content(content)
+            .characterEncoding("UTF-8")
+            .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andDo(print())
+        .andDo(document("delete-schedule-from-200",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("scheduleId").description("삭제할 일정 아이디"),
+                fieldWithPath("fromAt").description("해당 일시 이후 일정부터 삭제")
+            )
+        ));
+  }
+
+  @WithMockCustomUser
+  @DisplayName("스케쥴 삭제 API - 유효하지 않은 요청으로 인한 실패 400")
+  @Test
+  void deleteSchedule_invalidRequest() throws Exception {
+
+    // given
+    var request = DeleteScheduleRequestFixture.getInvalidDateRequest();
+    var content = objectMapper.writeValueAsString(request);
+
+    doThrow(new IllegalArgumentException("시작 시간이 종료 시간보다 이후일 수 없습니다."))
+        .when(scheduleFacade).deleteSchedule(any(Long.class), any());
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        delete("/api/v1/schedules")
+            .header("Authorization", "Bearer {ACCESS_TOKEN}")
+            .content(content)
+            .characterEncoding("UTF-8")
+            .contentType(MediaType.APPLICATION_JSON)
+    );
+
+    // then
+    resultActions.andExpect(status().isBadRequest())
+        .andDo(print())
+        .andDo(document("delete-schedule-invalid-400",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            getErrorResponseFieldSnippet()
+        ));
+  }
 }
+


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #242 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] 해당 일정 삭제 api
  - [x] 이후 일정 삭제 api

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 일정 삭제 기능 추가: 단일 일정 삭제 및 지정 시점 이후 반복 일정 일괄 삭제 API 제공.
  - 유효성 검증 및 오류 응답(400) 처리 강화.
- 문서
  - Schedule API에 “해당 일정 삭제”와 “이후 일정 삭제” 섹션 추가(요청/응답, 필드, 성공/실패 예시 포함).
- 테스트
  - 삭제 엔드포인트 통합 테스트 및 요청 DTO 픽스처 추가.
  - 컨트롤러 테스트에 정상/에러 시나리오 및 문서화 검증 포함.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->