### PR TITLE
[#72][fe][routine] 루틴 조회 및 업데이트 화면 추가

### DIFF
--- a/front/src/features/routine-task/useDailyTaskForm.js
+++ b/front/src/features/routine-task/useDailyTaskForm.js
@@ -35,7 +35,7 @@ export function useDailyTaskForm(task) {
     lastSentAt = Date.now()
     try {
       const req = {
-        id: task.id,
+        id: (typeof task.id === 'string' && task.id.includes('@')) ? null : task.id,
         routineTaskId: task.routineTaskId,
         currentValue: value,
         taskDate: task.date,

--- a/front/src/features/routine/api.js
+++ b/front/src/features/routine/api.js
@@ -1,0 +1,10 @@
+import axios from '@/api/axios'
+
+export const getRoutines = (params) => {
+  if (!params || typeof params !== 'object') {
+    throw new Error('유효하지 않은 params입니다.')
+  }
+  return axios.get('/v1/routine-task', {
+    params: params,
+  })
+}

--- a/front/src/features/routine/components/RoutineCard.vue
+++ b/front/src/features/routine/components/RoutineCard.vue
@@ -11,6 +11,7 @@
         <input
           type="checkbox"
           v-model="isChecked"
+          @change="updateCheck"
           class="w-5 h-5 text-indigo-500 accent-indigo-500"
         />
       </template>
@@ -26,53 +27,77 @@
             <img src="@/assets/chevron-down.svg" alt="Decrease" class="w-4 h-4 text-main-color" />
           </button>
 
-          <div class="text-sm font-semibold text-gray-800 w-6 text-center">{{ countValue }}</div>
+          <input
+            type="number"
+            v-model.number="countValue"
+            :min="0"
+            :max="maxCount"
+            class="text-sm font-semibold text-gray-800 w-8 text-center border rounded appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [&::-moz-appearance:textfield]"
+          />
 
           <button
             @click="increment"
+            :disabled="countValue >= maxCount"
             class="p-1 rounded hover:bg-indigo-100"
           >
-            <img src="@/assets/chevron-up.svg" alt="Increase" class="w-4 h-4 text-main-color" />
+            <img src="@/assets/chevron-up.svg" alt="Increase" class="w-4 h-4" />
           </button>
         </div>
       </template>
 
       <!-- 시간 분 루틴 -->
       <template v-else-if="routine.type === 'MINUTES'">
-        <div class="flex items-center space-x-6">
+        <div class="flex items-center space-x-2">
           <!-- 시간 -->
-          <div class="flex flex-col items-center space-y-1">
-            <button @click="increaseHour" class="p-1 rounded hover:bg-indigo-100">
+          <div class="flex flex-col items-center">
+            <button
+              @click="increaseHour"
+              class="flex justify-center items-center w-6 h-6 rounded hover:bg-indigo-100 mb-1"
+            >
               <img src="@/assets/chevron-up.svg" alt="Up" class="w-4 h-4 text-main-color" />
             </button>
-            <div class="text-sm font-semibold text-gray-800 w-[56px] text-center">
-              {{ hour }}시간
-            </div>
+            <input
+              type="number"
+              v-model.number="hour"
+              min="0"
+              class="text-sm font-semibold text-gray-800 w-8 text-center border rounded appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [&::-moz-appearance:textfield]"
+            />
             <button
               @click="decreaseHour"
               :disabled="currentValue < 60"
-              class="p-1 rounded hover:bg-indigo-100 disabled:opacity-30"
+              class="flex justify-center items-center w-6 h-6 rounded hover:bg-indigo-100 mt-1 disabled:opacity-30"
             >
               <img src="@/assets/chevron-down.svg" alt="Down" class="w-4 h-4 text-main-color" />
             </button>
           </div>
 
-          <!-- 분 -->
-          <div class="flex flex-col items-center space-y-1">
-            <button @click="increaseMinute" class="p-1 rounded hover:bg-indigo-100">
+          <span class="text-sm text-gray-700 mt-1 font-medium text-gray-800">시간</span>
+
+          <!-- 분-->
+          <div class="flex flex-col items-center ml-3">
+            <button
+              @click="increaseMinute"
+              class="flex justify-center items-center w-6 h-6 rounded hover:bg-indigo-100 mb-1"
+            >
               <img src="@/assets/chevron-up.svg" alt="Up" class="w-4 h-4 text-main-color" />
             </button>
-            <div class="text-sm font-semibold text-gray-800 w-[56px] text-center">
-              {{ minute }}분
-            </div>
+            <input
+              type="number"
+              v-model.number="minute"
+              min="0"
+              max="59"
+              class="text-sm font-semibold text-gray-800 w-8 text-center border rounded appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [&::-moz-appearance:textfield]"
+            />
             <button
               @click="decreaseMinute"
               :disabled="currentValue < minuteStep"
-              class="p-1 rounded hover:bg-indigo-100 disabled:opacity-30"
+              class="flex justify-center items-center w-6 h-6 rounded hover:bg-indigo-100 mt-1 disabled:opacity-30"
             >
               <img src="@/assets/chevron-down.svg" alt="Down" class="w-4 h-4 text-main-color" />
             </button>
           </div>
+
+          <span class="text-sm text-gray-700 mt-1 font-medium text-gray-800">분</span>
         </div>
       </template>
     </div>
@@ -80,55 +105,71 @@
 </template>
 
 <script setup>
-import { ref, watch, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
+import { useDailyTaskForm } from '@/features/routine-task/useDailyTaskForm'
 
 const props = defineProps({
-  routine: {
-    type: Object,
-    required: true,
+  routine: Object,
+  date: Date,
+})
+
+const { handleCheckboxChange, handleValueChange } = useDailyTaskForm(props.routine)
+
+// 체크박스
+const isChecked = ref(props.routine.currentValue >= 1)
+
+// COUNT
+const maxCount = props.routine.targetValue ?? 50
+const countValue = ref(props.routine.currentValue ?? 0)
+
+// MINUTES
+const currentValue = ref(props.routine.currentValue ?? 0)
+const minuteStep = 1
+
+// MINUTES input도 수정 가능하게 computed getter + setter
+const hour = computed({
+  get: () => Math.floor(currentValue.value / 60),
+  set: (val) => {
+    currentValue.value = val * 60 + (currentValue.value % 60)
   },
 })
 
-const isChecked = ref(props.routine.currentValue >= 1)
-const countValue = ref(props.routine.currentValue ?? 0)
-const maxCount = props.routine.targetValue ?? 50
-const minuteStep = 1
-
-const currentValue = ref(props.routine.currentValue ?? 0)
-
-const hour = computed(() => Math.floor(currentValue.value / 60))
-const minute = computed(() => currentValue.value % 60)
-
-watch(isChecked, (val) => {
-  console.log(`${props.routine.title} 완료 여부:`, val)
+const minute = computed({
+  get: () => currentValue.value % 60,
+  set: (val) => {
+    const h = Math.floor(currentValue.value / 60)
+    currentValue.value = h * 60 + val
+  },
 })
 
-watch(countValue, (val) => {
-  console.log(`${props.routine.title} 카운트 값:`, val)
+// === Watch & API ===
+watch(isChecked, (val, old) => {
+  if (val === old) return
+  handleCheckboxChange({ target: { checked: val } })
 })
 
-watch(currentValue, (val) => {
-  console.log(`${props.routine.title} 시간 값(분):`, val)
+watch(countValue, (val, old) => {
+  if (val === old) return
+  handleValueChange(val)
 })
 
-// COUNT용
+watch(currentValue, (val, old) => {
+  if (val === old) return
+  handleValueChange(val)
+})
+
+// === UI Actions ===
 const increment = () => {
-  countValue.value++
+  if (countValue.value < maxCount) countValue.value++
 }
 const decrement = () => {
   if (countValue.value > 0) countValue.value--
 }
-
-// MINUTES용 – maxCount 제한 제거
-const increaseHour = () => {
-  currentValue.value += 60
-}
+const increaseHour = () => (currentValue.value += 60)
 const decreaseHour = () => {
   if (currentValue.value >= 60) currentValue.value -= 60
 }
-const increaseMinute = () => {
-  currentValue.value += minuteStep
-}
+const increaseMinute = () => (currentValue.value += minuteStep)
 const decreaseMinute = () => {
   if (currentValue.value >= minuteStep) currentValue.value -= minuteStep
 }

--- a/front/src/features/routine/routineService.js
+++ b/front/src/features/routine/routineService.js
@@ -1,0 +1,11 @@
+import { getRoutines as getApi } from './api'
+import { wrapApi } from '@/shared/utils/errorUtils'
+
+export const getRoutines = wrapApi(async (fromDate, toDate) => {
+  const res = await getApi({
+    fromDate: fromDate,
+    toDate: toDate
+  })
+  return res
+}, {})
+

--- a/front/src/features/routine/useRoutineForm.js
+++ b/front/src/features/routine/useRoutineForm.js
@@ -21,9 +21,14 @@ export const useRoutineForm = (maybeSelectedDate = null) => {
       : [],
   )
 
-  const routinesForSelectedMonth = ref(
-    routineStore.getRoutinesMonthlyByDate(selectedDate.value),
-  )
+  const routinesForSelectedMonth = ref([])
+  const syncMonthlyRoutines = () => {
+    routinesForSelectedMonth.value = selectedDate.value
+    ? routineStore.getRoutinesMonthlyByDate(selectedDate.value) ?? []
+    : []
+  }
+
+  watch(selectedDate, syncMonthlyRoutines, { immediate: true })
 
   const startOfThisMonth = computed(() => datePickStore.monthRange.rangeStart)
   const startOfNextMonth = computed(() => datePickStore.monthRange.rangeEnd)
@@ -90,9 +95,7 @@ export const useRoutineForm = (maybeSelectedDate = null) => {
 
       if (t !== token) return // 최신 호출만 반영
 
-      routinesForSelectedMonth.value = routineStore.getRoutinesMonthlyByDate(
-        selectedDate.value,
-      )
+      syncMonthlyRoutines()
     },
     { immediate: true },
   )

--- a/front/src/features/routine/useRoutineForm.js
+++ b/front/src/features/routine/useRoutineForm.js
@@ -1,0 +1,110 @@
+import { computed, isRef, nextTick, reactive, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { format, differenceInCalendarDays, subDays, isSameDay } from 'date-fns'
+import { useRoutineStore } from '@/stores/useRoutineStore'
+import { useDatePickStore } from '@/stores/useDatePickStore'
+
+export const useRoutineForm = (maybeSelectedDate = null) => {
+  const datePickStore = useDatePickStore()
+  const routineStore = useRoutineStore()
+
+  const selectedDate =
+    maybeSelectedDate && isRef(maybeSelectedDate)
+      ? maybeSelectedDate
+      : ref(maybeSelectedDate ?? null)
+
+  const errorModal = reactive({})
+
+  const routinesForSelectedDate = computed(() =>
+    selectedDate.value
+      ? routineStore.getRoutinesForDate(selectedDate.value)
+      : [],
+  )
+
+  const routinesForSelectedMonth = ref(
+    routineStore.getRoutinesMonthlyByDate(selectedDate.value),
+  )
+
+  const startOfThisMonth = computed(() => datePickStore.monthRange.rangeStart)
+  const startOfNextMonth = computed(() => datePickStore.monthRange.rangeEnd)
+
+  const router = useRouter()
+
+  const goToRoutineDetail = (routine) => {
+    if (!routine?.id || !routine?.instanceDate) return
+
+    goToRoutineDetailOf(routine.id, routine.instanceDate)
+  }
+
+  const goToRoutineDetailOf = (id, instanceDate) => {
+    router.push({
+      name: 'schedule-modify',
+      params: {
+        id: id,
+        date: instanceDate,
+      },
+    })
+  }
+
+  const formatRoutinePeriod = (startAt, endAt) => {
+    const start = new Date(startAt)
+    const end = new Date(endAt)
+    const endMinus = subDays(end, 1)
+
+    const isAllDayStart = start.getHours() === 0 && start.getMinutes() === 0
+    const isAllDayEnd = end.getHours() === 0 && end.getMinutes() === 0
+    const isAllDay = isAllDayStart && isAllDayEnd
+    const oneDay = differenceInCalendarDays(end, start) === 1
+
+    if (isAllDay && oneDay) return '하루 종일'
+
+    const dateFormat = 'yyyy년 M월 d일'
+    const timeFormat = 'HH:mm'
+    const formatDateTime = (date, includeTime) =>
+      format(date, includeTime ? `${dateFormat} ${timeFormat}` : dateFormat)
+
+    const formattedStart = formatDateTime(start, !isAllDay)
+    const formattedEnd = formatDateTime(isAllDay ? endMinus : end, !isAllDay)
+
+    return `${formattedStart} ~ ${formattedEnd}`
+  }
+
+  const fetchRoutinesByPeriod = async (rangeStart, rangeEnd) => {
+    try {
+      await routineStore.loadMonthlyRoutinesIfNeeded(rangeStart, rangeEnd)
+    } catch (err) {
+      console.error(err)
+      errorModal.show = true
+      errorModal.msg = err?.message || '스케줄 조회 실패'
+    }
+  }
+
+  let token = 0
+  watch(
+    [startOfThisMonth, startOfNextMonth],
+    async ([s, n], [os, on]) => {
+      if (!s || !n || isSameDay(s, os)) return
+
+      const t = ++token
+      await fetchRoutinesByPeriod(s, n)
+
+      if (t !== token) return // 최신 호출만 반영
+
+      routinesForSelectedMonth.value = routineStore.getRoutinesMonthlyByDate(
+        selectedDate.value,
+      )
+    },
+    { immediate: true },
+  )
+
+  return {
+    selectedDate,
+    errorModal,
+    routinesForSelectedDate,
+    routinesForSelectedMonth,
+    goToRoutineDetail,
+    goToRoutineDetailOf,
+    formatRoutinePeriod,
+    fetchRoutinesByPeriod,
+  }
+}

--- a/front/src/features/routine/views/DailyRoutineView.vue
+++ b/front/src/features/routine/views/DailyRoutineView.vue
@@ -3,67 +3,16 @@ import { ref, watch } from 'vue'
 import WeeklyMonthlyDatePicker from '@/components/common/date-picker/WeeklyMonthlyDatePicker.vue'
 import RoutineCard from '@/features/routine/components/RoutineCard.vue'
 
+import { useRoutineForm } from '@/features/routine/useRoutineForm'
+
 const selectedDate = ref(new Date())
-const routines = ref([])
-
-//임시 더미 함수로 대체
-const fetchRoutinesByDate = async (date) => {
-  const day = new Date(date).getDate() // 날짜만 추출
-
-  if (day % 2 === 0) {
-    // 짝수 날짜
-    return [
-      {
-        id: 1,
-        routineTaskId: 201,
-        title: '아침 운동',
-        time: '07:00',
-        currentValue: 0,
-        targetValue: 90,
-        type: 'MINUTES',
-      },
-      {
-        id: 2,
-        routineTaskId: 202,
-        title: '저녁 명상',
-        time: '21:00',
-        currentValue: 1,
-        targetValue: 1,
-        type: 'CHECK',
-      },
-    ]
-  } else {
-    // 홀수 날짜
-    return [
-      {
-        id: 3,
-        routineTaskId: 301,
-        title: '점심 비타민',
-        time: '13:00',
-        currentValue: 0,
-        targetValue: 1,
-        type: 'CHECK',
-      },
-      {
-        id: 4,
-        routineTaskId: 302,
-        title: '물 5컵 마시기',
-        time: '10:00',
-        currentValue: 3,
-        targetValue: 5,
-        type: 'COUNT',
-      },
-    ]
-  }
-}
 
 
+const {
+  routinesForSelectedDate,
+} = useRoutineForm(selectedDate)
 
-const loadRoutines = async () => {
-  routines.value = await fetchRoutinesByDate(selectedDate.value)
-}
 
-watch(selectedDate, loadRoutines, { immediate: true })
 </script>
 
 <template>
@@ -72,7 +21,7 @@ watch(selectedDate, loadRoutines, { immediate: true })
       <WeeklyMonthlyDatePicker v-model="selectedDate" />
       <div class="mt-6 space-y-4 px-4">
         <RoutineCard
-          v-for="routine in routines"
+          v-for="routine in routinesForSelectedDate"
           :key="routine.id"
           :routine="routine"
           :date="selectedDate"

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -101,7 +101,7 @@ const router = createRouter({
           path: 'routine-task',
           component: () =>
             import('@/features/routine-task/views/RoutineTaskLayout.vue'),
-          redirect: '/routine-task/daily',
+          redirect: '/routine-task/daily/list',
           children: [
             {
               path: 'daily/list',

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -104,6 +104,14 @@ const router = createRouter({
           redirect: '/routine-task/daily',
           children: [
             {
+              path: 'daily/list',
+              name: 'routine-task-daily-list',
+              component: () =>
+                import(
+                  '@/features/routine/views/DailyRoutineView.vue'
+                  ),
+            },
+            {
               path: 'create',
               name: 'routine-task-create',
               component: () =>

--- a/front/src/shared/firebase/config.js
+++ b/front/src/shared/firebase/config.js
@@ -66,10 +66,6 @@ const MAX_SEEN = 1000
 const TRIM_COUNT = 500
 
 const bc = 'BroadcastChannel' in window ? new BroadcastChannel(DEDUPE_CH) : null
-bc?.onmessage = (e) => {
-  const { id, ts } = e.data || {}
-  if (id) seen.set(id, ts)
-}
 
 const markAndCheckSeen = (id) => {
   if (seen.has(id)) return true

--- a/front/src/shared/utils/rruleUtils.js
+++ b/front/src/shared/utils/rruleUtils.js
@@ -1,13 +1,13 @@
 import ICAL from 'ical.js'
 import {
-  parseISO,
-  format,
-  startOfMonth,
   endOfMonth,
+  format,
   isAfter,
-  isSameDay,
-  startOfDay,
   isBefore,
+  isSameDay,
+  parseISO,
+  startOfDay,
+  startOfMonth,
 } from 'date-fns'
 import { isAllDay } from './dateUtils'
 
@@ -33,11 +33,15 @@ function expandMultiDaySchedule(base, start, end, rangeStart, rangeEnd) {
   const result = []
 
   let startDate = new Date(start)
-  if (isBefore(startDate, rangeStart)) startDate = rangeStart
+  if (isBefore(startDate, rangeStart)) {
+    startDate = rangeStart
+  }
 
   for (let d = startOfDay(startDate); d < end; d.setDate(d.getDate() + 1)) {
     const dCopy = new Date(d)
-    if (isAfter(dCopy, rangeEnd)) break
+    if (isAfter(dCopy, rangeEnd)) {
+      break
+    }
 
     const dKey = format(dCopy, 'yyyy-MM-dd')
     result.push({
@@ -90,11 +94,15 @@ function expandRecurringSchedule(schedule, monthKey) {
   let next
   while ((next = iterator.next())) {
     const nextDate = next.toJSDate()
-    if (nextDate > rangeEnd) break
+    if (nextDate > rangeEnd) {
+      break
+    }
 
     const dateKey = format(nextDate, 'yyyy-MM-dd')
 
-    if (overrideDates.has(dateKey)) continue // 오버라이드는 아래 따로 추가
+    if (overrideDates.has(dateKey)) {
+      continue
+    } // 오버라이드는 아래 따로 추가
 
     const start = new Date(nextDate)
     const end = new Date(start.getTime() + durationMs)
@@ -136,19 +144,27 @@ function expandRecurringSchedule(schedule, monthKey) {
 
 const compareSchedule = (a, b) => {
   // 1) 여러날 일정 우선
-  if (a.isContinued !== b.isContinued) return a.isContinued ? -1 : 1
+  if (a.isContinued !== b.isContinued) {
+    return a.isContinued ? -1 : 1
+  }
 
   // 2) 하루종일(>=24h) 우선
   const aAll = isAllDay(a.startAt, a.endAt)
   const bAll = isAllDay(b.startAt, b.endAt)
-  if (aAll !== bAll) return aAll ? -1 : 1
+  if (aAll !== bAll) {
+    return aAll ? -1 : 1
+  }
 
   // 3) 시작시간 오름차순
   const as = new Date(a.startAt)
   const bs = new Date(b.startAt)
   if (as && bs) {
-    if (isBefore(as, bs)) return -1
-    if (isBefore(bs, as)) return 1
+    if (isBefore(as, bs)) {
+      return -1
+    }
+    if (isBefore(bs, as)) {
+      return 1
+    }
   } else if (as || bs) {
     // 시작시간 없는 건 뒤로
     return as ? -1 : 1
@@ -158,8 +174,12 @@ const compareSchedule = (a, b) => {
   const ae = new Date(a.endAt)
   const be = new Date(b.endAt)
   if (ae && be) {
-    if (isBefore(ae, be)) return -1
-    if (isBefore(be, ae)) return 1
+    if (isBefore(ae, be)) {
+      return -1
+    }
+    if (isBefore(be, ae)) {
+      return 1
+    }
   } else if (ae || be) {
     return ae ? -1 : 1
   }
@@ -183,7 +203,9 @@ export function expandSchedulesByDay(schedules, monthKey) {
       const dateKey = instance.instanceDate
       const instanceKey = `${instance.id}@${dateKey}`
 
-      if (!dailyMap[dateKey]) dailyMap[dateKey] = {}
+      if (!dailyMap[dateKey]) {
+        dailyMap[dateKey] = {}
+      }
 
       dailyMap[dateKey][instanceKey] = {
         ...instance,
@@ -200,28 +222,35 @@ export function expandRecurringRoutine(routine, monthKey) {
 
   // 비반복 루틴 (dailyProgress 기반)
   if (!recurrence || !recurrence.rruleStr) {
-    return routine.dailyProgress?.map(progress => {
-      const dateKey = format(new Date(progress.taskDate), 'yyyy-MM-dd')
-      return {
-        id: progress.dailyTaskId,
-        routineTaskId: routine.id,
-        title: routine.title,
-        time: routine.routineTimeInfo?.time?.slice(0, 5) ?? '',
-        currentValue: progress.currentValue ?? 0,
-        targetValue: routine.targetValue ?? 1,
-        type: routine.taskType,
-        instanceDate: dateKey,
-        completed: progress.completed ?? false,
-      }
-    }) || []
+    return (routine.dailyProgress ?? [])
+      .filter((progress) => {
+        const date = new Date(progress.taskDate)
+        return date >= rangeStart && date <= rangeEnd
+      })
+      .map((progress) => {
+        const dateKey = format(new Date(progress.taskDate), 'yyyy-MM-dd')
+        return {
+          id: progress.dailyTaskId,
+          routineTaskId: routine.id,
+          title: routine.title,
+          time: routine.routineTimeInfo?.time?.slice(0, 5) ?? '',
+          currentValue: progress.currentValue ?? 0,
+          targetValue: routine.targetValue ?? 1,
+          type: routine.taskType,
+          instanceDate: dateKey,
+          completed: progress.completed ?? false,
+        }
+      })
   }
 
   // 반복 규칙이 있는 루틴
   const startStr = recurrence.dtstart || routine.routineTimeInfo?.startDate
-  if (!startStr) return []
+  if (!startStr) {
+    return []
+  }
 
   const startDate = parseISO(startStr)
-  const endStr = routine.routineTimeInfo?.endDate || startStr
+  const endStr = routine.routineTimeInfo?.untilDate || startStr
   const endDate = parseISO(endStr)
   const durationMs = endDate.getTime() - startDate.getTime()
 
@@ -233,51 +262,59 @@ export function expandRecurringRoutine(routine, monthKey) {
 
   // ✅ dailyProgress를 Map으로 변환 (날짜 → progress 객체 전체)
   const progressMap = new Map(
-    (routine.dailyProgress || []).map(p => [
+    (routine.dailyProgress || []).map((p) => [
       format(new Date(p.taskDate), 'yyyy-MM-dd'),
       {
         id: p.dailyTaskId,
         currentValue: p.currentValue ?? 0,
         targetValue: p.targetValue ?? routine.targetValue ?? 1,
-        taskDate:p.taskDate,
+        taskDate: p.taskDate,
         completed: p.completed ?? false,
       },
-    ])
+    ]),
   )
-
   let next
+
+//  rangeStart 이전 반복들을 빠르게 스킵
   while ((next = iterator.next())) {
     const nextDate = next.toJSDate()
-    if (nextDate > rangeEnd) break
-    if (nextDate < rangeStart) continue
+    if (nextDate >= rangeStart) {
+      break
+    }
+  }
 
-    const dateKey = format(nextDate, 'yyyy-MM-dd')
-    if (seenDates.has(dateKey)) continue
-    seenDates.add(dateKey)
+// 💡 next가 rangeStart 이상인 상태에서 루프 시작
+  if (next && next.toJSDate() <= rangeEnd) {
+    do {
+      const nextDate = next.toJSDate()
+      const dateKey = format(nextDate, 'yyyy-MM-dd')
+      if (!seenDates.has(dateKey)) {
+        seenDates.add(dateKey)
 
-    const start = new Date(nextDate)
-    const end = new Date(start.getTime() + durationMs)
-    const progress = progressMap.get(dateKey)
+        const start = new Date(nextDate)
+        const end = new Date(start.getTime() + durationMs)
+        const progress = progressMap.get(dateKey)
 
-    result.push({
-      id: progress?.id ?? `${routine.id}@${dateKey}`,
-      routineTaskId: routine.id,
-      title: routine.title,
-      time: routine.routineTimeInfo?.time?.slice(0, 5) ?? '',
-      currentValue: progress?.currentValue ?? 0,
-      targetValue: progress?.targetValue ?? routine.targetValue ?? 1,
-      completed: progress?.completed ?? false,
-      date: progress?.taskDate ?? dateKey,
-      type: routine.taskType,
-      instanceDate: dateKey,
-      startAt: start.toISOString(),
-      endAt: end.toISOString(),
-    })
+        result.push({
+          id: progress?.id ?? `${routine.id}@${dateKey}`,
+          routineTaskId: routine.id,
+          title: routine.title,
+          time: routine.routineTimeInfo?.time?.slice(0, 5) ?? '',
+          currentValue: progress?.currentValue ?? 0,
+          targetValue: progress?.targetValue ?? routine.targetValue ?? 1,
+          completed: progress?.completed ?? false,
+          date: progress?.taskDate ?? dateKey,
+          type: routine.taskType,
+          instanceDate: dateKey,
+          startAt: start.toISOString(),
+          endAt: end.toISOString(),
+        })
+      }
+    } while ((next = iterator.next()) && next.toJSDate() <= rangeEnd)
   }
 
   return result
 }
-
 
 export function expandRoutinesByDay(routines, monthKey) {
   const dailyMap = {}
@@ -292,7 +329,9 @@ export function expandRoutinesByDay(routines, monthKey) {
       const dateKey = instance.instanceDate
       const instanceKey = `${instance.id}@${dateKey}`
 
-      if (!dailyMap[dateKey]) dailyMap[dateKey] = {}
+      if (!dailyMap[dateKey]) {
+        dailyMap[dateKey] = {}
+      }
 
       dailyMap[dateKey][instanceKey] = { ...instance }
     })
@@ -309,7 +348,9 @@ export function expandRoutineDates(rrule, dtstart, monthKey) {
   let next
   while ((next = iterator.next())) {
     const date = next.toJSDate()
-    if (date > rangeEnd) break
+    if (date > rangeEnd) {
+      break
+    }
     if (date >= rangeStart) {
       result.push(format(date, 'yyyy-MM-dd'))
     }

--- a/front/src/shared/utils/rruleUtils.js
+++ b/front/src/shared/utils/rruleUtils.js
@@ -194,6 +194,112 @@ export function expandSchedulesByDay(schedules, monthKey) {
   return { dailyMap, rawMap }
 }
 
+export function expandRecurringRoutine(routine, monthKey) {
+  const recurrence = routine.recurrenceRule
+  const { rangeStart, rangeEnd } = getMonthRange(monthKey)
+
+  // 비반복 루틴 (dailyProgress 기반)
+  if (!recurrence || !recurrence.rruleStr) {
+    return routine.dailyProgress?.map(progress => {
+      const dateKey = format(new Date(progress.taskDate), 'yyyy-MM-dd')
+      return {
+        id: progress.dailyTaskId,
+        routineTaskId: routine.id,
+        title: routine.title,
+        time: routine.routineTimeInfo?.time?.slice(0, 5) ?? '',
+        currentValue: progress.currentValue ?? 0,
+        targetValue: routine.targetValue ?? 1,
+        type: routine.taskType,
+        instanceDate: dateKey,
+        completed: progress.completed ?? false,
+      }
+    }) || []
+  }
+
+  // 반복 규칙이 있는 루틴
+  const startStr = recurrence.dtstart || routine.routineTimeInfo?.startDate
+  if (!startStr) return []
+
+  const startDate = parseISO(startStr)
+  const endStr = routine.routineTimeInfo?.endDate || startStr
+  const endDate = parseISO(endStr)
+  const durationMs = endDate.getTime() - startDate.getTime()
+
+  const event = createIcalComponent(recurrence.rruleStr, startDate)
+  const iterator = event.iterator(event.startDate)
+
+  const result = []
+  const seenDates = new Set()
+
+  // ✅ dailyProgress를 Map으로 변환 (날짜 → progress 객체 전체)
+  const progressMap = new Map(
+    (routine.dailyProgress || []).map(p => [
+      format(new Date(p.taskDate), 'yyyy-MM-dd'),
+      {
+        id: p.dailyTaskId,
+        currentValue: p.currentValue ?? 0,
+        targetValue: p.targetValue ?? routine.targetValue ?? 1,
+        taskDate:p.taskDate,
+        completed: p.completed ?? false,
+      },
+    ])
+  )
+
+  let next
+  while ((next = iterator.next())) {
+    const nextDate = next.toJSDate()
+    if (nextDate > rangeEnd) break
+    if (nextDate < rangeStart) continue
+
+    const dateKey = format(nextDate, 'yyyy-MM-dd')
+    if (seenDates.has(dateKey)) continue
+    seenDates.add(dateKey)
+
+    const start = new Date(nextDate)
+    const end = new Date(start.getTime() + durationMs)
+    const progress = progressMap.get(dateKey)
+
+    result.push({
+      id: progress?.id ?? `${routine.id}@${dateKey}`,
+      routineTaskId: routine.id,
+      title: routine.title,
+      time: routine.routineTimeInfo?.time?.slice(0, 5) ?? '',
+      currentValue: progress?.currentValue ?? 0,
+      targetValue: progress?.targetValue ?? routine.targetValue ?? 1,
+      completed: progress?.completed ?? false,
+      date: progress?.taskDate ?? dateKey,
+      type: routine.taskType,
+      instanceDate: dateKey,
+      startAt: start.toISOString(),
+      endAt: end.toISOString(),
+    })
+  }
+
+  return result
+}
+
+
+export function expandRoutinesByDay(routines, monthKey) {
+  const dailyMap = {}
+  const rawMap = {}
+
+  routines.forEach((task) => {
+    rawMap[task.id] = task
+
+    const instances = expandRecurringRoutine(task, monthKey)
+
+    instances.forEach((instance) => {
+      const dateKey = instance.instanceDate
+      const instanceKey = `${instance.id}@${dateKey}`
+
+      if (!dailyMap[dateKey]) dailyMap[dateKey] = {}
+
+      dailyMap[dateKey][instanceKey] = { ...instance }
+    })
+  })
+  return { dailyMap, rawMap }
+}
+
 export function expandRoutineDates(rrule, dtstart, monthKey) {
   const { rangeStart, rangeEnd } = getMonthRange(monthKey)
   const event = createIcalComponent(rrule, dtstart)

--- a/front/src/stores/useRoutineStore.js
+++ b/front/src/stores/useRoutineStore.js
@@ -61,8 +61,9 @@ export const useRoutineStore = defineStore(
     const getRoutinesForDate = (date) => {
       const dateKey = format(date, 'yyyy-MM-dd')
       const monthKey = dateKey.slice(0, 7)
+      const daily = dailyRoutines.value[monthKey]?.[dateKey]
 
-      return dailyRoutines.value[monthKey]?.[dateKey] || []
+      return daily ? Object.values(daily) : []
     }
 
     /**

--- a/front/src/stores/useRoutineStore.js
+++ b/front/src/stores/useRoutineStore.js
@@ -1,0 +1,125 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import { format } from 'date-fns'
+import { getPiniaStorage } from '@/shared/utils/piniaPersistUtils'
+import { getRoutines } from '@/features/routine/routineService'
+import { expandRoutinesByDay } from '@/shared/utils/rruleUtils.js' // 방금 만든 API 래퍼
+
+export const useRoutineStore = defineStore(
+  'routine',
+  () => {
+    /**
+     * 구조:
+     * {
+     *   '2025-09': {
+     *     '2025-09-21': [routine, routine, ...],
+     *     '2025-09-22': [routine, ...],
+     *     ...
+     *   },
+     *   ...
+     * }
+     */
+    const dailyRoutines = ref({})
+
+    // 서버 응답 원본 저장: 필요 시 재계산 가능
+    const rawRoutines = ref({}) // { '2025-09': [routineTaskResponse, ...] }
+
+    /**
+     * 월 단위로 기존 데이터 제거 후 새로 채움
+     */
+    const setMonthlyRoutines = (monthKey, routines) => {
+      if (!Array.isArray(routines)) return
+
+      const { dailyMap, rawMap } = expandRoutinesByDay(routines, monthKey)
+
+      rawRoutines.value[monthKey] = rawMap
+      dailyRoutines.value[monthKey] = dailyMap
+    }
+
+    /**
+     * 월간 키 존재 여부 확인
+     */
+    const hasMonth = (monthKey) => !!dailyRoutines.value[monthKey]
+
+    /**
+     * 해당 월 전체 일정 리스트 반환 (flat)
+     */
+    const getRoutinesMonthlyByDate = (date) => {
+      const monthKey = format(date, 'yyyy-MM')
+      const monthData = dailyRoutines.value[monthKey]
+
+      if (!monthData) return null
+
+      return Object.values(monthData).flatMap((instances) =>
+        Object.values(instances),
+      )
+    }
+
+    /**
+     * 특정 날짜의 루틴 목록 반환
+     */
+    const getRoutinesForDate = (date) => {
+      const dateKey = format(date, 'yyyy-MM-dd')
+      const monthKey = dateKey.slice(0, 7)
+
+      return dailyRoutines.value[monthKey]?.[dateKey] || []
+    }
+
+    /**
+     * 스토어 초기화
+     */
+    const reset = () => {
+      dailyRoutines.value = {}
+      rawRoutines.value = {}
+    }
+
+    // ↓↓↓ 공통 로더: 디바운스 + 중복요청 방지 (스케줄 스토어와 동일)
+    const _timers = new Map()
+    const _inflight = new Map()
+
+    async function loadMonthlyRoutinesIfNeeded(fromDate, toDate, delay = 300) {
+      const monthKey = format(fromDate, 'yyyy-MM')
+
+      if (hasMonth(monthKey)) return
+      if (_inflight.has(monthKey)) return _inflight.get(monthKey)
+      clearTimeout(_timers.get(monthKey))
+
+      const p = new Promise((resolve, reject) => {
+        const id = setTimeout(async () => {
+          _timers.delete(monthKey)
+
+          try {
+            const { data } = await getRoutines(
+              format(fromDate, 'yyyy-MM-dd'),
+              format(toDate, 'yyyy-MM-dd'),
+            )
+            setMonthlyRoutines(monthKey, data?.routineTasks || [])
+            resolve()
+          } catch (e) {
+            reject(e)
+          } finally {
+            _inflight.delete(monthKey)
+          }
+        }, delay)
+        _timers.set(monthKey, id)
+      })
+
+      _inflight.set(monthKey, p)
+      return p
+    }
+
+    return {
+      dailyRoutines,
+      rawRoutines,
+      setMonthlyRoutines,
+      hasMonth,
+      getRoutinesMonthlyByDate,
+      getRoutinesForDate,
+      reset,
+      loadMonthlyRoutinesIfNeeded,
+    }
+  },
+  {
+    persist: { storage: getPiniaStorage() },
+  },
+)


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #72 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 루틴 조회 및 업데이트 화면 추가

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
루틴 조회 및 업데이트 화면
<img width="960" height="853" alt="image" src="https://github.com/user-attachments/assets/95b0f534-3033-446b-8252-70c37e0870ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 일간 루틴 목록 화면 추가 및 라우트 제공.
  - 루틴 카드에서 카운트·시간(시/분) 값을 직접 입력하고 최소/최대 범위를 적용.
  - 체크박스 변경 시 즉시 반영되어 진행 상태 업데이트.
  - 선택한 날짜/월 범위에 맞춰 루틴을 자동 로드하고 날짜별로 표시.
  - 반복 루틴을 달력 범위에 맞게 전개하여 일자별 일정과 진행 상태를 정확히 보여줌.
- 개선
  - 데이터 로딩 안정성 향상 및 오류 발생 시 모달로 안내.
  - UI 배치와 라벨 등 가독성 소폭 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->