### PR TITLE
[#22][be][assistant] 일간 피드백 조회 api 추가

### DIFF
--- a/back/src/docs/asciidoc/feedback.adoc
+++ b/back/src/docs/asciidoc/feedback.adoc
@@ -24,3 +24,16 @@ include::{snippets}/create-feedback-invalid-user-mood-400/http-request.adoc[]
 ===== HTTP 응답 (400 Bad Request)
 include::{snippets}/create-feedback-invalid-user-mood-400/http-response.adoc[]
 ---
+
+[[Get-Daily-Feedbacks]]
+== 일간 피드백 조회 API
+=== 성공: 일간 피드백 조회
+
+==== HTTP 요청
+include::{snippets}/get-daily-feedbacks-200/http-request.adoc[]
+
+==== 요청 필드
+include::{snippets}/get-daily-feedbacks-200/path-parameters.adoc[]
+
+==== HTTP 응답 (200 OK)
+include::{snippets}/get-daily-feedbacks-200/http-response.adoc[]

--- a/back/src/docs/asciidoc/feedback.adoc
+++ b/back/src/docs/asciidoc/feedback.adoc
@@ -37,3 +37,13 @@ include::{snippets}/get-daily-feedbacks-200/path-parameters.adoc[]
 
 ==== HTTP 응답 (200 OK)
 include::{snippets}/get-daily-feedbacks-200/http-response.adoc[]
+
+=== 실패: 유효성 검증 오류
+
+==== 유효하지 않은 미래 일자 요청값 오류
+
+===== HTTP 요청
+include::{snippets}/get-daily-feedbacks-invalid-date-400/http-request.adoc[]
+
+===== HTTP 응답 (400 Bad Request)
+include::{snippets}/get-daily-feedbacks-invalid-date-400/http-response.adoc[]

--- a/back/src/main/java/com/rouby/assistant/feedback/application/dto/GetDailyFeedbacksInfo.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/application/dto/GetDailyFeedbacksInfo.java
@@ -1,0 +1,49 @@
+package com.rouby.assistant.feedback.application.dto;
+
+import com.rouby.assistant.feedback.domain.entity.Feedback;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record GetDailyFeedbacksInfo(
+    List<GetFeedbackInfo> feedbacks
+) {
+
+  public static GetDailyFeedbacksInfo from(List<Feedback> feedbacks) {
+
+    if (feedbacks == null || feedbacks.isEmpty()) {
+      return new GetDailyFeedbacksInfo(Collections.emptyList());
+    }
+
+    return GetDailyFeedbacksInfo.builder()
+        .feedbacks(feedbacks.stream().map(GetFeedbackInfo::from).toList())
+        .build();
+  }
+
+  @Builder
+  public record GetFeedbackInfo(
+      int slot,
+      String userInput,
+      String userMood,
+      String feedbackContent,
+      String status,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt
+  ) {
+
+    public static GetFeedbackInfo from(Feedback feedback) {
+
+      return GetFeedbackInfo.builder()
+          .slot(feedback.getSlot())
+          .userInput(feedback.getUserInput())
+          .userMood(feedback.getMood().toString())
+          .feedbackContent(feedback.getFeedbackContent().getContent())
+          .status(feedback.getStatus().toString())
+          .createdAt(feedback.getCreatedAt())
+          .updatedAt(feedback.getUpdatedAt())
+          .build();
+    }
+  }
+}

--- a/back/src/main/java/com/rouby/assistant/feedback/application/dto/GetDailyFeedbacksInfo.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/application/dto/GetDailyFeedbacksInfo.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.List;
 import lombok.Builder;
 
-@Builder
 public record GetDailyFeedbacksInfo(
     List<GetFeedbackInfo> feedbacks
 ) {
@@ -17,9 +16,7 @@ public record GetDailyFeedbacksInfo(
       return new GetDailyFeedbacksInfo(Collections.emptyList());
     }
 
-    return GetDailyFeedbacksInfo.builder()
-        .feedbacks(feedbacks.stream().map(GetFeedbackInfo::from).toList())
-        .build();
+    return new GetDailyFeedbacksInfo(feedbacks.stream().map(GetFeedbackInfo::from).toList());
   }
 
   @Builder

--- a/back/src/main/java/com/rouby/assistant/feedback/application/service/FeedbackReadService.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/application/service/FeedbackReadService.java
@@ -1,7 +1,9 @@
 package com.rouby.assistant.feedback.application.service;
 
 import com.rouby.assistant.feedback.application.dto.FeedbackInfoForNewFeedback;
+import com.rouby.assistant.feedback.application.dto.GetDailyFeedbacksInfo;
 import com.rouby.assistant.feedback.domain.entity.Feedback;
+import com.rouby.assistant.feedback.domain.entity.enums.Status;
 import com.rouby.assistant.feedback.domain.repository.FeedbackRepository;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +22,13 @@ public class FeedbackReadService {
             userId, currentAt.minusDays(7), currentAt)
         .orElse(null);
     return FeedbackInfoForNewFeedback.from(recentFeedback);
+  }
+
+  public GetDailyFeedbacksInfo getDailyFeedbacks(Long userId, LocalDate date) {
+
+    GetDailyFeedbacksInfo info = GetDailyFeedbacksInfo.from(
+        feedbackRepository.findByUserIdAndFeedbackDateAndStatusAndDeletedAtIsNull(
+            userId, date, Status.COMPLETED));
+    return info;
   }
 }

--- a/back/src/main/java/com/rouby/assistant/feedback/application/service/FeedbackReadService.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/application/service/FeedbackReadService.java
@@ -26,9 +26,8 @@ public class FeedbackReadService {
 
   public GetDailyFeedbacksInfo getDailyFeedbacks(Long userId, LocalDate date) {
 
-    GetDailyFeedbacksInfo info = GetDailyFeedbacksInfo.from(
+    return GetDailyFeedbacksInfo.from(
         feedbackRepository.findByUserIdAndFeedbackDateAndStatusAndDeletedAtIsNull(
             userId, date, Status.COMPLETED));
-    return info;
   }
 }

--- a/back/src/main/java/com/rouby/assistant/feedback/application/usecase/CreateFeedbackUsecase.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/application/usecase/CreateFeedbackUsecase.java
@@ -82,9 +82,7 @@ public class CreateFeedbackUsecase {
       throw e;
     }
 
-
     TEMPERATURE = 0.5;
-
     assistantGateway.requestDailyFeedbackAsync(
         PROMPT_VERSION,
         TEMPERATURE,

--- a/back/src/main/java/com/rouby/assistant/feedback/domain/repository/FeedbackRepository.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/domain/repository/FeedbackRepository.java
@@ -1,8 +1,10 @@
 package com.rouby.assistant.feedback.domain.repository;
 
 import com.rouby.assistant.feedback.domain.entity.Feedback;
+import com.rouby.assistant.feedback.domain.entity.enums.Status;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface FeedbackRepository {
@@ -17,4 +19,6 @@ public interface FeedbackRepository {
   void markFailure(Long feedbackId, Long userId);
 
   Optional<Feedback> findByIdAndDeletedAtIsNull(Long feedbackId);
+
+  List<Feedback> findByUserIdAndFeedbackDateAndStatusAndDeletedAtIsNull(Long userId, LocalDate date, Status status);
 }

--- a/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepository.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/infrastructure/persistence/jpa/FeedbackJpaRepository.java
@@ -1,9 +1,11 @@
 package com.rouby.assistant.feedback.infrastructure.persistence.jpa;
 
 import com.rouby.assistant.feedback.domain.entity.Feedback;
+import com.rouby.assistant.feedback.domain.entity.enums.Status;
 import com.rouby.assistant.feedback.domain.repository.FeedbackRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -16,6 +18,8 @@ public interface FeedbackJpaRepository extends
 
   Optional<Feedback> findTop1ByUserIdAndCreatedAtBetweenOrderByCreatedAtDesc(
       Long userId, LocalDateTime fromAt, LocalDateTime toAt);
+
+  List<Feedback> findByUserIdAndFeedbackDateAndStatusAndDeletedAtIsNull(Long userId, LocalDate date, Status status);
 
   @Query("""
     SELECT MAX(fb.slot) FROM Feedback fb

--- a/back/src/main/java/com/rouby/assistant/feedback/presentation/FeedbackController.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/presentation/FeedbackController.java
@@ -1,13 +1,18 @@
 package com.rouby.assistant.feedback.presentation;
 
+import com.rouby.assistant.feedback.application.service.FeedbackReadService;
 import com.rouby.assistant.feedback.application.usecase.CreateFeedbackUsecase;
 import com.rouby.assistant.feedback.presentation.dto.CreateFeedbackRequest;
+import com.rouby.assistant.feedback.presentation.dto.GetDailyFeedbacksResponse;
 import com.rouby.user.user.infrastructure.security.dto.SecurityUser;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FeedbackController {
 
   private final CreateFeedbackUsecase createFeedbackUsecase;
+  private final FeedbackReadService feedbackReadService;
 
   @PreAuthorize("hasAnyRole('USER')")
   @PostMapping
@@ -28,5 +34,16 @@ public class FeedbackController {
 
     createFeedbackUsecase.requestFeedback(request.toCommand(user.getId()));
     return ResponseEntity.accepted().build();
+  }
+
+  @PreAuthorize("hasAnyRole('USER')")
+  @GetMapping("/daily/{date}")
+  public ResponseEntity<GetDailyFeedbacksResponse> getDailyFeedback(
+      @AuthenticationPrincipal SecurityUser user,
+      @PathVariable LocalDate date) {
+
+    GetDailyFeedbacksResponse res = GetDailyFeedbacksResponse.from(
+        feedbackReadService.getDailyFeedbacks(user.getId(), date));
+    return ResponseEntity.ok(res);
   }
 }

--- a/back/src/main/java/com/rouby/assistant/feedback/presentation/FeedbackController.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/presentation/FeedbackController.java
@@ -5,6 +5,7 @@ import com.rouby.assistant.feedback.application.usecase.CreateFeedbackUsecase;
 import com.rouby.assistant.feedback.presentation.dto.CreateFeedbackRequest;
 import com.rouby.assistant.feedback.presentation.dto.GetDailyFeedbacksResponse;
 import com.rouby.user.user.infrastructure.security.dto.SecurityUser;
+import jakarta.validation.constraints.PastOrPresent;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +41,7 @@ public class FeedbackController {
   @GetMapping("/daily/{date}")
   public ResponseEntity<GetDailyFeedbacksResponse> getDailyFeedback(
       @AuthenticationPrincipal SecurityUser user,
-      @PathVariable LocalDate date) {
+      @PathVariable @PastOrPresent LocalDate date) {
 
     GetDailyFeedbacksResponse res = GetDailyFeedbacksResponse.from(
         feedbackReadService.getDailyFeedbacks(user.getId(), date));

--- a/back/src/main/java/com/rouby/assistant/feedback/presentation/dto/GetDailyFeedbacksResponse.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/presentation/dto/GetDailyFeedbacksResponse.java
@@ -3,21 +3,16 @@ package com.rouby.assistant.feedback.presentation.dto;
 import com.rouby.assistant.feedback.application.dto.GetDailyFeedbacksInfo;
 import com.rouby.assistant.feedback.application.dto.GetDailyFeedbacksInfo.GetFeedbackInfo;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import lombok.Builder;
 
-@Builder
 public record GetDailyFeedbacksResponse(
     List<GetDailyFeedbackResponse> feedbacks
 ) {
 
   public static GetDailyFeedbacksResponse from(GetDailyFeedbacksInfo feedbacksInfo) {
-    return GetDailyFeedbacksResponse.builder()
-        .feedbacks(feedbacksInfo.feedbacks() == null || feedbacksInfo.feedbacks().isEmpty()
-            ? Collections.emptyList()
-            : feedbacksInfo.feedbacks().stream().map(GetDailyFeedbackResponse::from).toList())
-        .build();
+    return new GetDailyFeedbacksResponse(
+        feedbacksInfo.feedbacks().stream().map(GetDailyFeedbackResponse::from).toList());
   }
 
   @Builder

--- a/back/src/main/java/com/rouby/assistant/feedback/presentation/dto/GetDailyFeedbacksResponse.java
+++ b/back/src/main/java/com/rouby/assistant/feedback/presentation/dto/GetDailyFeedbacksResponse.java
@@ -1,0 +1,45 @@
+package com.rouby.assistant.feedback.presentation.dto;
+
+import com.rouby.assistant.feedback.application.dto.GetDailyFeedbacksInfo;
+import com.rouby.assistant.feedback.application.dto.GetDailyFeedbacksInfo.GetFeedbackInfo;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record GetDailyFeedbacksResponse(
+    List<GetDailyFeedbackResponse> feedbacks
+) {
+
+  public static GetDailyFeedbacksResponse from(GetDailyFeedbacksInfo feedbacksInfo) {
+    return GetDailyFeedbacksResponse.builder()
+        .feedbacks(feedbacksInfo.feedbacks() == null || feedbacksInfo.feedbacks().isEmpty()
+            ? Collections.emptyList()
+            : feedbacksInfo.feedbacks().stream().map(GetDailyFeedbackResponse::from).toList())
+        .build();
+  }
+
+  @Builder
+  record GetDailyFeedbackResponse(
+      int slot,
+      String userMood,
+      String userInput,
+      String feedbackContent,
+      LocalDateTime createdAt,
+      LocalDateTime updatedAt
+  ) {
+
+    public static GetDailyFeedbackResponse from(GetFeedbackInfo info) {
+
+      return GetDailyFeedbackResponse.builder()
+          .slot(info.slot())
+          .userMood(info.userMood())
+          .userInput(info.userInput())
+          .feedbackContent(info.feedbackContent())
+          .createdAt(info.createdAt())
+          .updatedAt(info.updatedAt())
+          .build();
+    }
+  }
+}

--- a/back/src/test/http/feedback.http
+++ b/back/src/test/http/feedback.http
@@ -1,3 +1,4 @@
+### 피드백 생성 요청
 POST {{url}}/api/v1/assistants/feedbacks
 content-type: application/json
 
@@ -5,3 +6,6 @@ content-type: application/json
   "userInput": "오늘은 집중이 잘 안 되는 하루였던 거 같아. 빨리 집중해서 취업해야 되는데...!",
   "userMood": "SOSO"
 }
+
+### 일간 피드백 리스트 요청
+GET {{url}}/api/v1/assistants/feedbacks/daily/2025-10-19

--- a/back/src/test/http/feedback.http
+++ b/back/src/test/http/feedback.http
@@ -8,4 +8,4 @@ content-type: application/json
 }
 
 ### 일간 피드백 리스트 요청
-GET {{url}}/api/v1/assistants/feedbacks/daily/2025-10-19
+GET {{url}}/api/v1/assistants/feedbacks/daily/2025-10-22

--- a/back/src/test/java/com/rouby/assistant/feedback/presentation/FeedbackControllerTest.java
+++ b/back/src/test/java/com/rouby/assistant/feedback/presentation/FeedbackControllerTest.java
@@ -1,20 +1,31 @@
 package com.rouby.assistant.feedback.presentation;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.rouby.assistant.feedback.application.dto.GetDailyFeedbacksInfo;
+import com.rouby.assistant.feedback.application.dto.GetDailyFeedbacksInfo.GetFeedbackInfo;
 import com.rouby.assistant.feedback.fixture.CreateDailyFeedbackRequestFixture;
 import com.rouby.common.security.WithMockCustomUser;
 import com.rouby.common.support.ControllerTestSupport;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -77,6 +88,53 @@ class FeedbackControllerTest extends ControllerTestSupport {
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
             getValidationErrorResponseFieldSnippet()
+        ));
+  }
+
+  @WithMockCustomUser
+  @DisplayName("일간 피드백 리스트 요청 API: 성공 200")
+  @Test
+  void getDailyFeedbacks() throws Exception {
+
+    GetDailyFeedbacksInfo feedbacksInfo = GetDailyFeedbacksInfo.builder()
+        .feedbacks(IntStream.range(0, 3)
+            .mapToObj(i -> GetFeedbackInfo.builder()
+                .slot(i + 1)
+                .userMood("SOSO")
+                .userInput("사용자 요청 입력값 " + i + 1)
+                .feedbackContent("피드백 응답 데이터 " + i + 1)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build())
+            .toList())
+        .build();
+
+    when(feedbackReadService.getDailyFeedbacks(eq(1L), any(LocalDate.class)))
+        .thenReturn(feedbacksInfo);
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/v1/assistants/feedbacks/daily/{date}", LocalDate.now())
+            .header("Authorization", "Bearer {ACCESS_TOKEN}")
+    );
+
+    // then
+    resultActions.andExpect(status().isOk())
+        .andDo(print())
+        .andDo(document("get-daily-feedbacks-200",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("date").description("조회할 날짜 (YYYY-MM-DD)")
+            ),
+            responseFields(
+                fieldWithPath("feedbacks[].slot").description("요청 횟수 (최대 3)"),
+                fieldWithPath("feedbacks[].userMood").description("사용자 기분 (TERRIBLE, BAD, SOSO, GOOD, EXCELLENT)"),
+                fieldWithPath("feedbacks[].userInput").description("사용자 입력값"),
+                fieldWithPath("feedbacks[].feedbackContent").description("피드백 내용"),
+                fieldWithPath("feedbacks[].createdAt").description("피드백 생성 요청 일시 (예: 2025-09-15T10:00:00)"),
+                fieldWithPath("feedbacks[].updatedAt").description("피드백 생성 일시 (예: 2025-09-15T10:00:00)")
+            )
         ));
   }
 }

--- a/back/src/test/java/com/rouby/assistant/feedback/presentation/FeedbackControllerTest.java
+++ b/back/src/test/java/com/rouby/assistant/feedback/presentation/FeedbackControllerTest.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -96,18 +97,17 @@ class FeedbackControllerTest extends ControllerTestSupport {
   @Test
   void getDailyFeedbacks() throws Exception {
 
-    GetDailyFeedbacksInfo feedbacksInfo = GetDailyFeedbacksInfo.builder()
-        .feedbacks(IntStream.range(0, 3)
+    GetDailyFeedbacksInfo feedbacksInfo = new GetDailyFeedbacksInfo(
+        IntStream.range(0, 3)
             .mapToObj(i -> GetFeedbackInfo.builder()
                 .slot(i + 1)
                 .userMood("SOSO")
-                .userInput("사용자 요청 입력값 " + i + 1)
-                .feedbackContent("피드백 응답 데이터 " + i + 1)
+                .userInput("사용자 요청 입력값 " + (i + 1))
+                .feedbackContent("피드백 응답 데이터 " + (i + 1))
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build())
-            .toList())
-        .build();
+            .toList());
 
     when(feedbackReadService.getDailyFeedbacks(eq(1L), any(LocalDate.class)))
         .thenReturn(feedbacksInfo);
@@ -136,5 +136,27 @@ class FeedbackControllerTest extends ControllerTestSupport {
                 fieldWithPath("feedbacks[].updatedAt").description("피드백 생성 일시 (예: 2025-09-15T10:00:00)")
             )
         ));
+  }
+
+  @WithMockCustomUser
+  @DisplayName("일간 피드백 리스트 요청 API: 잘못된 일자 요청으로 인한 실패 400")
+  @Test
+  void getDailyFeedbacksWithFutureDate_return400() throws Exception {
+
+    // when
+    ResultActions resultActions = mockMvc.perform(
+        get("/api/v1/assistants/feedbacks/daily/{date}", LocalDate.now().plusDays(1))
+            .header("Authorization", "Bearer {ACCESS_TOKEN}")
+            .header(HttpHeaders.ACCEPT_LANGUAGE, "ko-KR")
+    );
+
+    // then
+    resultActions.andExpect(status().isBadRequest())
+        .andDo(print())
+        .andDo(document("get-daily-feedbacks-invalid-date-400",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            getValidationErrorResponseFieldSnippet()
+            ));
   }
 }

--- a/back/src/test/java/com/rouby/common/support/ControllerTestSupport.java
+++ b/back/src/test/java/com/rouby/common/support/ControllerTestSupport.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rouby.assistant.briefing.application.facade.BriefingFacade;
 import com.rouby.assistant.briefing.presentation.BriefingController;
+import com.rouby.assistant.feedback.application.service.FeedbackReadService;
 import com.rouby.assistant.feedback.application.usecase.CreateFeedbackUsecase;
 import com.rouby.assistant.feedback.presentation.FeedbackController;
 import com.rouby.assistant.prompt.application.service.PromptWriteService;
@@ -91,6 +92,9 @@ public abstract class ControllerTestSupport {
 
   @MockitoBean
   protected BriefingFacade briefingFacade;
+
+  @MockitoBean
+  protected FeedbackReadService feedbackReadService;
 
   @MockitoBean
   protected CreateFeedbackUsecase createFeedbackUsecase;


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolve: #22

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 일간 피드백 조회 api 추가
  - [x] 일간 피드백 조회 api 테스트 추가
  

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [x] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 날짜의 피드백을 조회할 수 있는 새로운 API 엔드포인트 추가
  * 완료된 피드백만 필터링하여 조회 가능

* **문서**
  * 일일 피드백 조회 API 문서 추가

* **테스트**
  * 새로운 피드백 조회 기능에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->